### PR TITLE
Task/26 task support for andorsubshell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
+          persist-credentials: true
       - name: Install libreadline-dev
         run: sudo apt-get update && sudo apt-get install -y libreadline-dev
       - name: make

--- a/config.mk
+++ b/config.mk
@@ -20,12 +20,15 @@ SRC_FILES = main.c \
 			$(LEX_DIR)/lexer_helpers.c \
 			$(LEX_DIR)/token.c \
 			$(PARSER_DIR)/parser.c \
+			$(PARSER_DIR)/parser_input.c \
 			$(PARSER_DIR)/parser_helpers.c \
 			$(AST_DIR)/ast.c \
 			$(AST_DIR)/free_ast.c \
 			$(AST_DIR)/parse_ast_rules.c \
 			$(AST_DIR)/parse_cmd_rules.c \
 			$(EVAL_DIR)/eval.c \
+			$(EVAL_DIR)/eval_nodes.c \
+			$(EVAL_DIR)/eval_helpers.c \
 			$(EVAL_DIR)/eval_util.c \
 			$(EVAL_DIR)/cmd_res.c \
 			$(EVAL_DIR)/util.c \

--- a/inc/eval.h
+++ b/inc/eval.h
@@ -15,6 +15,8 @@
 
 # include "ast.h"
 # include "hashtable.h"
+# include "lexer.h"
+# include "parser.h"
 # include <stdlib.h>
 
 # define INPUT_END 0
@@ -31,121 +33,142 @@ typedef enum s_cmd_type
 	CMD_UNSET,
 	CMD_ECHO,
 	CMD_EXIT,
-}						t_cmd_type;
+}								t_cmd_type;
+
+typedef struct s_shell_response	t_shell_response;
+typedef struct s_cmd_response	t_cmd_response;
+typedef struct s_shell_env		t_shell_env;
+typedef struct s_cmd_func_call	t_cmd_func_call;
 
 typedef struct s_shell_response
 {
-	char				*curr_dir;
-	int					exit_code;
-}						t_shell_response;
+	int							exit_code;
+}								t_shell_response;
 
 typedef struct s_cmd_response
 {
-	char				*curr_dir;
-	int					exit_code;
-}						t_cmd_response;
+	int							exit_code;
+}								t_cmd_response;
 
 typedef struct s_shell_env
 {
-	int					last_exit_code;
-	int					og_stdout_fd;
-	int					og_stdin_fd;
-	char				**envp;
-	t_hashtable			*vars;
-	t_list				*order;
-	t_ast				*root_node;
-}						t_shell_env;
+	t_cmd_func_call				*current_call;
+	int							interactive_owner;
+	int							last_exit_code;
+	int							og_stdout_fd;
+	int							og_stdin_fd;
+	char						*current_input;
+	char						**envp;
+	t_hashtable					*vars;
+	t_list						*order;
+	t_lexer						*lexer;
+	t_parser					*parser;
+	t_ast						*root_node;
+}								t_shell_env;
 
-typedef t_cmd_response	*(*t_cmd_func)(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *shell_env);
+typedef t_cmd_response			*(*t_cmd_func)(t_ast *shell_ast, char **cmd_str,
+									t_shell_env *shell_env);
 
 typedef struct s_cmd_func_call
 {
-	int					is_builtin;
-	t_cmd_func			cmd_func;
-	t_shell_env			*env;
-	char				**cmd_str;
-	char				**envp;
-}						t_cmd_func_call;
+	int							is_builtin;
+	t_cmd_func					cmd_func;
+	t_shell_env					*env;
+	char						**cmd_str;
+	char						**envp;
+}								t_cmd_func_call;
 
-t_shell_response		*eval_ast(t_ast *shell_ast, t_shell_env *env);
+t_shell_response				*eval_ast(t_ast *shell_ast, t_shell_env *env);
 
-char					**get_cmd_str(char *cmd_name, t_ast *cmd_suffix,
-							char *envp[]);
-void					free_cmd_str(char **cmd_str);
+char							**get_cmd_str(char *cmd_name, t_ast *cmd_suffix,
+									t_shell_env *env);
+void							free_cmd_str(char **cmd_str);
 
-char					**get_bin_paths(char *envp[]);
-int						check_path(char *path, char *argv);
-int						check_builtin(char *cmd_name);
+char							**get_bin_paths(t_shell_env *env);
+int								check_path(char *path, char *argv);
+int								check_builtin(char *cmd_name);
 
-t_cmd_response			*func_exec_cmd(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
-t_cmd_response			*func_built_in_cd(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
-t_cmd_response			*func_built_in_echo(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
-t_cmd_response			*func_built_in_env(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
-t_cmd_response			*func_built_in_exit(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
+t_cmd_response					*func_exec_cmd(t_ast *shell_ast, char **cmd_str,
+									t_shell_env *env);
+t_cmd_response					*func_built_in_cd(t_ast *shell_ast,
+									char **cmd_str, t_shell_env *env);
+t_cmd_response					*func_built_in_echo(t_ast *shell_ast,
+									char **cmd_str, t_shell_env *env);
+t_cmd_response					*func_built_in_env(t_ast *shell_ast,
+									char **cmd_str, t_shell_env *env);
+t_cmd_response					*func_built_in_exit(t_ast *shell_ast,
+									char **cmd_str, t_shell_env *env);
 
-char					*build_plain_env_line(char *key, char *value);
-void					append_env_plain_line(char **output, char *key,
-							t_shell_env *env);
-char					*build_env_line(char *key, char *value);
-void					append_env_line(char **output, char *key,
-							t_shell_env *env);
-int						process_export_arg(char *arg, t_shell_env *env,
-							char **error);
-t_cmd_response			*func_built_in_export(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
+char							*build_plain_env_line(char *key, char *value);
+void							append_env_plain_line(char **output, char *key,
+									t_shell_env *env);
+char							*build_env_line(char *key, char *value);
+void							append_env_line(char **output, char *key,
+									t_shell_env *env);
+int								process_export_arg(char *arg, t_shell_env *env,
+									char **error);
+t_cmd_response					*func_built_in_export(t_ast *shell_ast,
+									char **cmd_str, t_shell_env *env);
 
-t_cmd_response			*func_built_in_pwd(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
-t_cmd_response			*func_built_in_unset(t_ast *shell_ast, char **cmd_str,
-							t_shell_env *env);
+t_cmd_response					*func_built_in_pwd(t_ast *shell_ast,
+									char **cmd_str, t_shell_env *env);
+t_cmd_response					*func_built_in_unset(t_ast *shell_ast,
+									char **cmd_str, t_shell_env *env);
 
-t_shell_env				*create_shell_env(char *envp[]);
-void					*destroy_shell_env(t_shell_env *env);
+t_shell_env						*create_shell_env(char *envp[]);
+void							*destroy_shell_env(t_shell_env *env);
 
-t_cmd_response			*create_cmd_res(void);
-void					*destroy_cmd_res(t_cmd_response *cmd_res);
+t_cmd_response					*create_cmd_res(void);
+void							*destroy_cmd_res(t_cmd_response *cmd_res);
 
-void					save_original_std_fds(t_shell_env *env);
-void					restore_original_std_fds(t_shell_env *env);
-void					child_exit(t_shell_env *env, t_ast *local_ast,
-							int code);
+void							save_original_std_fds(t_shell_env *env);
+void							restore_original_std_fds(t_shell_env *env);
+void							child_exit(t_shell_env *env, t_ast *local_ast,
+									int code);
 
 typedef struct s_pipe_context
 {
-	int	*writer;
-	int	*reader;
-	int	prev_pipe_fd_read_end;
-}						t_pipe_context;
+	int							*writer;
+	int							*reader;
+	int							prev_pipe_fd_read_end;
+	pid_t						left_pid;
+}								t_pipe_context;
 
-t_cmd_response			*handle_parent(pid_t pid);
+t_cmd_response					*handle_parent(pid_t pid);
 
-void					func_exec_cmd_pipe(t_ast *ast, t_shell_env *env,
-							int *pipe_fd, int prev_pipe_read_fd);
-void					eval_pipe_recursive(t_ast *shell_ast, t_shell_env *env,
-							int *pipefd, int prev_read_end);
+void							run_pipe_child(t_ast *ast, t_shell_env *env,
+									t_pipe_context *ctx);
+void							func_exec_cmd_pipe(t_ast *ast, t_shell_env *env,
+									int *pipe_fd, int prev_pipe_read_fd);
+void							eval_pipe_recursive(t_ast *shell_ast,
+									t_shell_env *env, int *pipefd,
+									int prev_read_end);
 
-t_cmd_response			*eval_external_cmd(t_ast *shell_ast,
-							t_cmd_func_call *call);
-t_cmd_response			*exec_call(t_ast *ast, t_cmd_func_call *call);
+t_cmd_response					*eval_cmd(t_ast *shell_ast, t_shell_env *env);
+t_cmd_response					*eval_pipe(t_ast *shell_ast, t_shell_env *env);
+t_cmd_response					*eval_subshell(t_ast *shell_ast,
+									t_shell_env *env);
+t_cmd_response					*eval_and_or(t_ast *shell_ast,
+									t_shell_env *env);
 
-char					*read_line_interactive(void);
-char					*read_line_noninteractive(void);
-int						should_stop_heredoc(char *line, char *delimiter);
-char					*generate_heredoc_filename(void);
-int						write_heredoc_to_file(char *delimiter, char *filename);
-int						process_heredocs(t_ast *node, t_shell_env *env);
-void					cleanup_heredoc_files(t_ast *ast);
-int						eval_redir(t_ast *shell_ast);
+t_cmd_response					*eval_external_cmd(t_ast *shell_ast,
+									t_cmd_func_call *call);
+t_cmd_response					*exec_call(t_ast *ast, t_cmd_func_call *call);
 
-char					*get_curdir(void);
-t_cmd_func				get_cmd_func(char *cmd_name);
-t_cmd_func_call			*check_cmd(t_ast *shell_ast, t_shell_env *env);
-size_t					num_arguments(char **cmd_str);
+char							*read_line_interactive(void);
+char							*read_line_noninteractive(void);
+int								should_stop_heredoc(char *line,
+									char *delimiter);
+char							*generate_heredoc_filename(void);
+int								write_heredoc_to_file(char *delimiter,
+									char *filename);
+int								process_heredocs(t_ast *node, t_shell_env *env);
+void							cleanup_heredoc_files(t_ast *ast);
+int								eval_redir(t_ast *shell_ast);
+
+char							*get_curdir(void);
+t_cmd_func						get_cmd_func(char *cmd_name);
+t_cmd_func_call					*check_cmd(t_ast *shell_ast, t_shell_env *env);
+size_t							num_arguments(char **cmd_str);
 
 #endif

--- a/inc/parser.h
+++ b/inc/parser.h
@@ -14,6 +14,8 @@
 # define PARSER_H
 # include "lexer.h"
 
+typedef struct s_shell_env	t_shell_env;
+
 typedef struct s_parser
 {
 	t_lexer	*lexer;
@@ -21,6 +23,8 @@ typedef struct s_parser
 	t_token	*peek_token;
 	int		has_error;
 }	t_parser;
+
+void		parse_input(char *input, t_shell_env *env);
 
 t_parser	*create_parser(t_lexer *lexer);
 void		next_token(t_parser *parser);

--- a/inc/token.h
+++ b/inc/token.h
@@ -28,7 +28,7 @@ typedef enum s_token_type
 	LPAREN,
 	RPAREN,
 	EQUAL,
-	END,
+	NEWLINE,
 	ILLEGAL,
 }	t_token_type;
 

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -143,11 +143,13 @@ t_ast	*init_ast(t_parser *parser)
 {
 	t_ast	*root;
 
-	if (cur_token_is(parser->cur_token, (1 << END)))
+	if (cur_token_is(parser->cur_token, (1 << NEWLINE)))
 		return (NULL);
 	root = parse_and_or(parser);
-	if (cur_token_is(parser->cur_token, (1 << RPAREN))
-		|| !cur_token_is(parser->cur_token, (1 << END)))
+	if (root == NULL)
+		return (NULL);
+	if (!parser->has_error && (cur_token_is(parser->cur_token, (1 << RPAREN))
+			|| !cur_token_is(parser->cur_token, (1 << NEWLINE))))
 	{
 		parser_error(parser);
 		return (free_ast(root));

--- a/src/ast/parse_ast_rules.c
+++ b/src/ast/parse_ast_rules.c
@@ -80,7 +80,8 @@ t_ast	*parse_simple_cmd(t_parser *parser)
 		return (parse_subshell(parser));
 	}
 	cmd_prefix = parse_cmd_prefix(parser);
-	if (!cur_token_is(parser->cur_token, (1 << WORD)) && !parser->has_error)
+	if (!cur_token_is(parser->cur_token, (1 << WORD) | (1 << NEWLINE))
+			&& !parser->has_error)
 		return (parser_error(parser));
 	cmd_name = parser->cur_token->literal;
 	next_token(parser);

--- a/src/ast/parse_ast_rules.c
+++ b/src/ast/parse_ast_rules.c
@@ -53,7 +53,7 @@ t_ast	*parse_pipe_sequence(t_parser *parser)
 	{
 		next_token(parser);
 		if (cur_token_is(parser->cur_token, (1 << PIPE) | (1 << AND_IF)
-				| (1 << OR_IF) | (1 << END)))
+				| (1 << OR_IF) | (1 << NEWLINE)))
 		{
 			parser_error(parser);
 			return (free_ast(left));
@@ -80,7 +80,7 @@ t_ast	*parse_simple_cmd(t_parser *parser)
 		return (parse_subshell(parser));
 	}
 	cmd_prefix = parse_cmd_prefix(parser);
-	if (!cur_token_is(parser->cur_token, (1 << WORD)))
+	if (!cur_token_is(parser->cur_token, (1 << WORD)) && !parser->has_error)
 		return (parser_error(parser));
 	cmd_name = parser->cur_token->literal;
 	next_token(parser);

--- a/src/ast/parse_ast_rules.c
+++ b/src/ast/parse_ast_rules.c
@@ -11,8 +11,8 @@
 /* ************************************************************************** */
 
 #include "ast.h"
-#include "parser.h"
 #include "libft.h"
+#include "parser.h"
 
 t_ast	*parse_and_or(t_parser *parser)
 {
@@ -26,8 +26,8 @@ t_ast	*parse_and_or(t_parser *parser)
 	{
 		node.u_ast.s_and_or.op = parser->cur_token;
 		next_token(parser);
-		if (cur_token_is(parser->cur_token, (1 << AND_IF) | (1 << OR_IF)
-				| (1 << PIPE) | (1 << AMPERSAND)))
+		if (cur_token_is(parser->cur_token,
+				(1 << AND_IF) | (1 << OR_IF) | (1 << PIPE) | (1 << AMPERSAND)))
 		{
 			parser_error(parser);
 			return (free_ast(node.u_ast.s_and_or.left));
@@ -52,8 +52,8 @@ t_ast	*parse_pipe_sequence(t_parser *parser)
 	while (cur_token_is(parser->cur_token, (1 << PIPE)))
 	{
 		next_token(parser);
-		if (cur_token_is(parser->cur_token, (1 << PIPE) | (1 << AND_IF)
-				| (1 << OR_IF) | (1 << NEWLINE)))
+		if (cur_token_is(parser->cur_token,
+				(1 << PIPE) | (1 << AND_IF) | (1 << OR_IF) | (1 << NEWLINE)))
 		{
 			parser_error(parser);
 			return (free_ast(left));
@@ -68,6 +68,23 @@ t_ast	*parse_pipe_sequence(t_parser *parser)
 	return (left);
 }
 
+static t_ast	*build_simple_cmd(t_ast *prefix, char *name, t_ast *suffix)
+{
+	return (create_ast((t_ast){.type = AST_SIMPLE_CMD,
+			.u_ast.s_simple_cmd.cmd_prefix = prefix,
+			.u_ast.s_simple_cmd.cmd_name = name,
+			.u_ast.s_simple_cmd.cmd_suffix = suffix}));
+}
+
+static t_ast	*parse_prefix_only_cmd(t_parser *parser, t_ast *cmd_prefix)
+{
+	if (!cmd_prefix && !parser->has_error)
+		return (parser_error(parser));
+	if (!cmd_prefix)
+		return (NULL);
+	return (build_simple_cmd(cmd_prefix, NULL, NULL));
+}
+
 t_ast	*parse_simple_cmd(t_parser *parser)
 {
 	t_ast	*cmd_prefix;
@@ -80,52 +97,14 @@ t_ast	*parse_simple_cmd(t_parser *parser)
 		return (parse_subshell(parser));
 	}
 	cmd_prefix = parse_cmd_prefix(parser);
-	if (!cur_token_is(parser->cur_token, (1 << WORD) | (1 << NEWLINE))
-			&& !parser->has_error)
+	if (cur_token_is(parser->cur_token, (1 << NEWLINE)))
+		return (parse_prefix_only_cmd(parser, cmd_prefix));
+	if (!cur_token_is(parser->cur_token, (1 << WORD)) && !parser->has_error)
 		return (parser_error(parser));
 	cmd_name = parser->cur_token->literal;
 	next_token(parser);
 	cmd_suffix = parse_cmd_suffix(parser);
 	if (parser->has_error)
 		return (NULL);
-	return (create_ast((t_ast){.type = AST_SIMPLE_CMD,
-			.u_ast.s_simple_cmd.cmd_prefix = cmd_prefix,
-			.u_ast.s_simple_cmd.cmd_name = cmd_name,
-			.u_ast.s_simple_cmd.cmd_suffix = cmd_suffix}));
-}
-
-t_ast	*parse_cmd_prefix(t_parser *parser)
-{
-	t_ast	*io_file;
-	t_ast	*cmd_prefix;
-
-	io_file = parse_io_redirect(parser);
-	if (!io_file)
-		return (NULL);
-	cmd_prefix = parse_cmd_prefix(parser);
-	return (create_ast((t_ast){.type = AST_CMD_PREFIX,
-			.u_ast.s_cmd_prefix.io_file = io_file,
-			.u_ast.s_cmd_prefix.cmd_prefix = cmd_prefix}));
-}
-
-t_ast	*parse_cmd_suffix(t_parser *parser)
-{
-	t_ast		node;
-
-	node.type = AST_CMD_SUFFIX;
-	node.u_ast.s_cmd_suffix.io_file = parse_io_redirect(parser);
-	if (node.u_ast.s_cmd_suffix.io_file)
-	{
-		node.u_ast.s_cmd_suffix.cmd_suffix = parse_cmd_suffix(parser);
-		node.u_ast.s_cmd_suffix.word = NULL;
-		return (create_ast(node));
-	}
-	if (!cur_token_is(parser->cur_token, (1 << WORD)))
-		return (NULL);
-	node.u_ast.s_cmd_suffix.word = parser->cur_token->literal;
-	next_token(parser);
-	node.u_ast.s_cmd_suffix.cmd_suffix = parse_cmd_suffix(parser);
-	if (parser->has_error)
-		return (NULL);
-	return (create_ast(node));
+	return (build_simple_cmd(cmd_prefix, cmd_name, cmd_suffix));
 }

--- a/src/ast/parse_cmd_rules.c
+++ b/src/ast/parse_cmd_rules.c
@@ -49,3 +49,39 @@ t_ast	*parse_io_redirect(t_parser *parser)
 		.u_ast.s_io_file.op = op};
 	return (create_ast(node));
 }
+
+t_ast	*parse_cmd_prefix(t_parser *parser)
+{
+	t_ast	*io_file;
+	t_ast	*cmd_prefix;
+
+	io_file = parse_io_redirect(parser);
+	if (!io_file)
+		return (NULL);
+	cmd_prefix = parse_cmd_prefix(parser);
+	return (create_ast((t_ast){.type = AST_CMD_PREFIX,
+			.u_ast.s_cmd_prefix.io_file = io_file,
+			.u_ast.s_cmd_prefix.cmd_prefix = cmd_prefix}));
+}
+
+t_ast	*parse_cmd_suffix(t_parser *parser)
+{
+	t_ast	node;
+
+	node.type = AST_CMD_SUFFIX;
+	node.u_ast.s_cmd_suffix.io_file = parse_io_redirect(parser);
+	if (node.u_ast.s_cmd_suffix.io_file)
+	{
+		node.u_ast.s_cmd_suffix.cmd_suffix = parse_cmd_suffix(parser);
+		node.u_ast.s_cmd_suffix.word = NULL;
+		return (create_ast(node));
+	}
+	if (!cur_token_is(parser->cur_token, (1 << WORD)))
+		return (NULL);
+	node.u_ast.s_cmd_suffix.word = parser->cur_token->literal;
+	next_token(parser);
+	node.u_ast.s_cmd_suffix.cmd_suffix = parse_cmd_suffix(parser);
+	if (parser->has_error)
+		return (NULL);
+	return (create_ast(node));
+}

--- a/src/eval/builtin/cd.c
+++ b/src/eval/builtin/cd.c
@@ -13,33 +13,107 @@
 #include "ast.h"
 #include "eval.h"
 #include "libft.h"
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
-//TODO: fix cd using oldpwd and pwd
+static void	update_env_var(t_shell_env *env, const char *key, char *value)
+{
+	char	*old_value;
+
+	old_value = hashtable_get(env->vars, key);
+	if (old_value)
+		free(old_value);
+	hashtable_set(env->vars, key, value);
+}
+
+static char	*get_target_dir(char **cmd_str, t_shell_env *env, int *print_pwd)
+{
+	char	*path;
+
+	if (!cmd_str[1])
+	{
+		path = hashtable_get(env->vars, "HOME");
+		if (!path)
+			ft_dprintf(STDERR_FILENO, "minishell: cd: HOME not set\n");
+	}
+	else if (ft_strncmp(cmd_str[1], "-", 2) == 0)
+	{
+		path = hashtable_get(env->vars, "OLDPWD");
+		if (!path)
+			ft_dprintf(STDERR_FILENO, "minishell: cd: OLDPWD not set\n");
+		else
+			*print_pwd = 1;
+	}
+	else
+		path = cmd_str[1];
+	return (path);
+}
+
+static int	change_dir_and_update(t_shell_env *env, char *path, char *old_pwd)
+{
+	char	*new_pwd;
+
+	if (chdir(path) == -1)
+	{
+		ft_dprintf(STDERR_FILENO, "minishell: cd: %s: %s\n", path,
+			strerror(errno));
+		free(old_pwd);
+		return (1);
+	}
+	update_env_var(env, "OLDPWD", old_pwd);
+	new_pwd = ft_calloc(1, PATH_MAX + 1);
+	if (!new_pwd)
+		return (1);
+	if (getcwd(new_pwd, PATH_MAX))
+		update_env_var(env, "PWD", new_pwd);
+	else
+		free(new_pwd);
+	return (0);
+}
+
+static t_cmd_response	*init_cd_response(char **cmd_str)
+{
+	t_cmd_response	*res;
+
+	res = ft_calloc(1, sizeof(t_cmd_response));
+	if (!res)
+		return (NULL);
+	if (num_arguments(cmd_str) > 1)
+	{
+		ft_dprintf(STDERR_FILENO, "minishell: cd: too many arguments\n");
+		res->exit_code = 1;
+	}
+	return (res);
+}
+
 t_cmd_response	*func_built_in_cd(t_ast *shell_ast, char **cmd_str,
 		t_shell_env *env)
 {
 	t_cmd_response	*res;
-	size_t			num_args;
+	char			*path;
+	char			*old_pwd;
+	int				print_pwd;
 
 	(void)shell_ast;
-	(void)env;
-	res = ft_calloc(1, sizeof(t_cmd_response));
-	if (!res)
-		return (NULL);
-	num_args = num_arguments(cmd_str);
-	if (num_args == 1)
+	res = init_cd_response(cmd_str);
+	if (!res || res->exit_code)
+		return (res);
+	print_pwd = 0;
+	path = get_target_dir(cmd_str, env, &print_pwd);
+	if (!path)
 	{
-		chdir(cmd_str[1]);
-		res->curr_dir = get_curdir();
-		res->exit_code = 0;
-	}
-	else if (num_args > 1)
-	{
-		ft_dprintf(STDERR_FILENO, "too many arguments\n");
 		res->exit_code = 1;
 		return (res);
 	}
+	old_pwd = ft_calloc(1, PATH_MAX + 1);
+	if (old_pwd)
+		getcwd(old_pwd, PATH_MAX);
+	res->exit_code = change_dir_and_update(env, path, old_pwd);
+	if (res->exit_code == 0 && print_pwd)
+		ft_dprintf(STDOUT_FILENO, "%s\n", hashtable_get(env->vars, "PWD"));
 	return (res);
 }

--- a/src/eval/builtin/echo.c
+++ b/src/eval/builtin/echo.c
@@ -15,72 +15,58 @@
 #include "libft.h"
 #include <unistd.h>
 
-static char	*append_word(char *output, const char *word)
+static int	is_newline_flag(char *arg)
 {
-	char	*tmp;
-	char	*result;
+	int	i;
 
-	if (!output)
+	if (!arg || arg[0] != '-' || !arg[1])
+		return (0);
+	i = 1;
+	while (arg[i])
 	{
-		if (!word)
-			return (ft_strdup(""));
-		return (ft_strdup(word));
+		if (arg[i] != 'n')
+			return (0);
+		i++;
 	}
-	tmp = ft_strjoin(output, " ");
-	free(output);
-	result = ft_strjoin(tmp, word);
-	free(tmp);
-	return (result);
+	return (1);
 }
 
-static char	*build_output(t_ast *node, int *newline_flag)
+static void	print_echo_args(char **cmd_str, int start_idx, int newline)
 {
-	char	*output;
+	int	i;
 
-	output = NULL;
-	while (node)
+	i = start_idx;
+	while (cmd_str[i])
 	{
-		if (node->u_ast.s_cmd_suffix.word)
-		{
-			if (ft_strcmp(node->u_ast.s_cmd_suffix.word, "-n") == 0)
-				*newline_flag = 0;
-			else
-				output = append_word(output, node->u_ast.s_cmd_suffix.word);
-		}
-		node = node->u_ast.s_cmd_suffix.cmd_suffix;
+		ft_dprintf(STDOUT_FILENO, "%s", cmd_str[i]);
+		if (cmd_str[i + 1])
+			ft_dprintf(STDOUT_FILENO, " ");
+		i++;
 	}
-	if (!output)
-		return (ft_strdup(""));
-	return (output);
+	if (newline)
+		ft_dprintf(STDOUT_FILENO, "\n");
 }
 
-//TODO: fix echo adding support for multiple -n and -nnnnn..
 t_cmd_response	*func_built_in_echo(t_ast *shell_ast, char **cmd_str,
 		t_shell_env *env)
 {
 	t_cmd_response	*res;
-	char			*output;
-	char			*tmp;
-	int				newline_flag;
+	int				i;
+	int				newline;
 
-	(void)cmd_str;
+	(void)shell_ast;
 	(void)env;
-	if (!shell_ast)
-		return (NULL);
 	res = ft_calloc(1, sizeof(t_cmd_response));
 	if (!res)
 		return (NULL);
-	newline_flag = 1;
-	output = build_output(shell_ast->u_ast.s_simple_cmd.cmd_suffix,
-			&newline_flag);
-	if (newline_flag)
+	i = 1;
+	newline = 1;
+	while (cmd_str[i] && is_newline_flag(cmd_str[i]))
 	{
-		tmp = ft_strjoin(output, "\n");
-		free(output);
-		output = tmp;
+		newline = 0;
+		i++;
 	}
+	print_echo_args(cmd_str, i, newline);
 	res->exit_code = 0;
-	ft_dprintf(STDOUT_FILENO, "%s", output);
-	free(output);
 	return (res);
 }

--- a/src/eval/builtin/env.c
+++ b/src/eval/builtin/env.c
@@ -15,6 +15,22 @@
 #include "libft.h"
 #include <unistd.h>
 
+static t_cmd_response	*init_env_res(char **output)
+{
+	t_cmd_response	*res;
+
+	*output = ft_strdup("");
+	if (!*output)
+		return (NULL);
+	res = ft_calloc(1, sizeof(t_cmd_response));
+	if (!res)
+	{
+		free(*output);
+		return (NULL);
+	}
+	return (res);
+}
+
 t_cmd_response	*func_built_in_env(t_ast *shell_ast, char **cmd_str,
 		t_shell_env *env)
 {
@@ -24,19 +40,14 @@ t_cmd_response	*func_built_in_env(t_ast *shell_ast, char **cmd_str,
 
 	(void)shell_ast;
 	(void)cmd_str;
-	output = ft_strdup("");
-	if (!output)
-		return (NULL);
-	res = ft_calloc(1, sizeof(t_cmd_response));
+	res = init_env_res(&output);
 	if (!res)
-	{
-		free(output);
 		return (NULL);
-	}
 	node = env->order;
 	while (node)
 	{
-		append_env_plain_line(&output, (char *)node->content, env);
+		if (hashtable_get(env->vars, (char *)node->content))
+			append_env_plain_line(&output, (char *)node->content, env);
 		node = node->next;
 	}
 	ft_dprintf(STDOUT_FILENO, "%s", output);

--- a/src/eval/builtin/exit.c
+++ b/src/eval/builtin/exit.c
@@ -6,36 +6,103 @@
 /*   By: hermarti <hermarti@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/12/03 11:44:09 by hermarti          #+#    #+#             */
-/*   Updated: 2025/12/29 17:02:40 by hermarti         ###   ########.fr       */
+/*   Updated: 2026/01/29 18:00:54 by hermarti         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ast.h"
 #include "eval.h"
 #include "libft.h"
+#include <limits.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-//TODO: make exit really exit minishell
+static int	check_overflow(unsigned long long res, int digit, int sign,
+				int next)
+{
+	if (res > (unsigned long long)LLONG_MAX / 10)
+		return (0);
+	if (res == (unsigned long long)LLONG_MAX / 10 && digit > (LLONG_MAX % 10))
+	{
+		if (sign == -1 && digit == 8 && !next)
+			return (1);
+		return (0);
+	}
+	return (1);
+}
+
+static int	check_exit_arg(char *arg)
+{
+	int					i;
+	int					sign;
+	unsigned long long	result;
+
+	i = 0;
+	sign = 1;
+	if (arg[i] == '+' || arg[i] == '-')
+	{
+		if (arg[i] == '-')
+			sign = -1;
+		i++;
+	}
+	if (!arg[i])
+		return (0);
+	result = 0;
+	while (arg[i])
+	{
+		if (!ft_isdigit(arg[i]))
+			return (0);
+		if (!check_overflow(result, arg[i] - '0', sign, arg[i + 1]))
+			return (0);
+		result = (result * 10) + (arg[i] - '0');
+		i++;
+	}
+	return (1);
+}
+
+static void	exit_no_args(t_ast *ast, t_shell_env *env, t_cmd_response *res)
+{
+	int	exit_code;
+
+	exit_code = 0;
+	if (env)
+		exit_code = env->last_exit_code;
+	destroy_cmd_res(res);
+	child_exit(env, ast, exit_code);
+}
+
+static void	exit_invalid_arg(t_ast *ast, char **cmd, t_shell_env *env,
+					t_cmd_response *res)
+{
+	ft_dprintf(STDERR_FILENO, "minishell: exit: %s: numeric argument required\n",
+		cmd[1]);
+	destroy_cmd_res(res);
+	child_exit(env, ast, 2);
+}
+
 t_cmd_response	*func_built_in_exit(t_ast *shell_ast, char **cmd_str,
 		t_shell_env *env)
 {
 	t_cmd_response	*res;
 	size_t			num_args;
 
-	(void)shell_ast;
-	(void)env;
 	res = ft_calloc(1, sizeof(t_cmd_response));
 	if (!res)
 		return (NULL);
+	if (env && env->interactive_owner && isatty(STDIN_FILENO))
+		ft_dprintf(STDERR_FILENO, "exit\n");
 	num_args = num_arguments(cmd_str);
-	if (num_args >= 1)
+	if (num_args == 0)
+		exit_no_args(shell_ast, env, res);
+	if (!check_exit_arg(cmd_str[1]))
+		exit_invalid_arg(shell_ast, cmd_str, env, res);
+	if (num_args >= 2)
 	{
-		ft_dprintf(STDERR_FILENO, "too many arguments\n");
+		ft_dprintf(STDERR_FILENO, "minishell: exit: too many arguments\n");
 		res->exit_code = 1;
 		return (res);
 	}
-	ft_dprintf(STDERR_FILENO, "exit\n");
-	res->exit_code = 0;
-	return (res);
+	destroy_cmd_res(res);
+	child_exit(env, shell_ast, (unsigned char)ft_atoll(cmd_str[1]));
+	return (NULL);
 }

--- a/src/eval/builtin/exit.c
+++ b/src/eval/builtin/exit.c
@@ -74,8 +74,8 @@ static void	exit_no_args(t_ast *ast, t_shell_env *env, t_cmd_response *res)
 static void	exit_invalid_arg(t_ast *ast, char **cmd, t_shell_env *env,
 					t_cmd_response *res)
 {
-	ft_dprintf(STDERR_FILENO, "minishell: exit: %s: numeric argument required\n",
-		cmd[1]);
+	ft_dprintf(STDERR_FILENO,
+		"minishell: exit: %s: numeric argument required\n", cmd[1]);
 	destroy_cmd_res(res);
 	child_exit(env, ast, 2);
 }

--- a/src/eval/builtin/export.c
+++ b/src/eval/builtin/export.c
@@ -25,7 +25,8 @@ char	*export_no_args(t_shell_env *env)
 	node = env->order;
 	while (node)
 	{
-		append_env_line(&res, (char *)node->content, env);
+		if (ft_strncmp((char *)node->content, "_", 2) != 0)
+			append_env_line(&res, (char *)node->content, env);
 		node = node->next;
 	}
 	return (res);
@@ -60,7 +61,6 @@ static void	print_and_free(char *out, char *err)
 	free(err);
 }
 
-//TODO: remove var _ from the export no args print
 t_cmd_response	*func_built_in_export(t_ast *ast, char **cmd, t_shell_env *env)
 {
 	char			*out;

--- a/src/eval/builtin/export.c
+++ b/src/eval/builtin/export.c
@@ -25,7 +25,7 @@ char	*export_no_args(t_shell_env *env)
 	node = env->order;
 	while (node)
 	{
-		if (ft_strncmp((char *)node->content, "_", 2) != 0)
+		if (ft_strncmp((char *)node->content, "_", 1) != 0)
 			append_env_line(&res, (char *)node->content, env);
 		node = node->next;
 	}

--- a/src/eval/builtin/export_args_util.c
+++ b/src/eval/builtin/export_args_util.c
@@ -13,24 +13,15 @@
 #include "eval.h"
 #include "libft.h"
 
-char	*build_error_msg(char *arg)
-{
-	char	*msg;
-	char	*tmp;
-
-	msg = ft_strjoin("minishell: `", arg);
-	tmp = msg;
-	msg = ft_strjoin(tmp, "': not a valid identifier\n");
-	free(tmp);
-	return (msg);
-}
-
-void	append_error(char **erro_msg, char *arg)
+static void	append_error(char **erro_msg, char *arg)
 {
 	char	*new_err;
 	char	*tmp;
 
-	new_err = build_error_msg(arg);
+	new_err = ft_strjoin("minishell: `", arg);
+	tmp = new_err;
+	new_err = ft_strjoin(tmp, "': not a valid identifier\n");
+	free(tmp);
 	if (*erro_msg == NULL)
 		*erro_msg = new_err;
 	else
@@ -46,7 +37,10 @@ void	export_var(t_shell_env *env, char *var, char *equal_pos)
 {
 	if (!hashtable_get(env->vars, var))
 		ft_lstadd_back(&env->order, ft_lstnew(ft_strdup(var)));
-	hashtable_set(env->vars, var, ft_strdup(equal_pos + 1));
+	if (equal_pos)
+		hashtable_set(env->vars, var, ft_strdup(equal_pos + 1));
+	else
+		hashtable_set(env->vars, var, NULL);
 }
 
 int	check_var_name(char *var_name)
@@ -67,14 +61,12 @@ int	check_var_name(char *var_name)
 	return (1);
 }
 
-int	process_export_arg(char *arg, t_shell_env *env, char **error)
+static int	handle_equal_export(char *arg, t_shell_env *env, char **error)
 {
 	char	*var;
 	char	*equal_pos;
 
 	equal_pos = ft_strchr(arg, '=');
-	if (!equal_pos)
-		return (0);
 	var = ft_substr(arg, 0, equal_pos - arg);
 	if (check_var_name(var))
 		export_var(env, var, equal_pos);
@@ -85,5 +77,25 @@ int	process_export_arg(char *arg, t_shell_env *env, char **error)
 		return (1);
 	}
 	free(var);
+	return (0);
+}
+
+int	process_export_arg(char *arg, t_shell_env *env, char **error)
+{
+	char	*equal_pos;
+
+	equal_pos = ft_strchr(arg, '=');
+	if (equal_pos)
+		return (handle_equal_export(arg, env, error));
+	if (check_var_name(arg))
+	{
+		if (!hashtable_get(env->vars, arg))
+			export_var(env, arg, NULL);
+	}
+	else
+	{
+		append_error(error, arg);
+		return (1);
+	}
 	return (0);
 }

--- a/src/eval/builtin/export_no_args_util.c
+++ b/src/eval/builtin/export_no_args_util.c
@@ -21,16 +21,18 @@ char	*build_env_line(char *key, char *value)
 
 	line = ft_strjoin("declare -x ", key);
 	tmp = line;
-	line = ft_strjoin(tmp, "=\"");
-	free(tmp);
-	tmp = line;
 	if (value)
+	{
+		line = ft_strjoin(tmp, "=\"");
+		free(tmp);
+		tmp = line;
 		line = ft_strjoin(tmp, value);
+		free(tmp);
+		tmp = line;
+		line = ft_strjoin(tmp, "\"\n");
+	}
 	else
-		line = ft_strjoin(tmp, "");
-	free(tmp);
-	tmp = line;
-	line = ft_strjoin(tmp, "\"\n");
+		line = ft_strjoin(tmp, "\n");
 	free(tmp);
 	return (line);
 }

--- a/src/eval/cmd/cmd_str.c
+++ b/src/eval/cmd/cmd_str.c
@@ -75,7 +75,7 @@ static char	**build_cmd_str(char *cmd_name, t_ast *cmd_suffix, char *bin_path)
 	return (cmd_str);
 }
 
-char	**get_cmd_str(char *cmd_name, t_ast *cmd_suffix, char *envp[])
+char	**get_cmd_str(char *cmd_name, t_ast *cmd_suffix, t_shell_env *env)
 {
 	char	**cmd_str;
 	char	**bin_paths;
@@ -85,7 +85,7 @@ char	**get_cmd_str(char *cmd_name, t_ast *cmd_suffix, char *envp[])
 		return (build_cmd_str(cmd_name, cmd_suffix, ""));
 	if (check_builtin(cmd_name))
 		return (build_cmd_str(cmd_name, cmd_suffix, ""));
-	bin_paths = get_bin_paths(envp);
+	bin_paths = get_bin_paths(env);
 	i = 0;
 	while (bin_paths[i])
 	{

--- a/src/eval/cmd/cmd_str_helpers.c
+++ b/src/eval/cmd/cmd_str_helpers.c
@@ -10,30 +10,22 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "eval.h"
 #include "libft.h"
 #include <unistd.h>
 
-//TODO: Don't use envp use the hashtable to handle cases like unset PATH
-char	**get_bin_paths(char *envp[])
+char	**get_bin_paths(t_shell_env *env)
 {
-	char	**default_paths;
+	char	*path_value;
+	char	**empty_paths;
 
-	while (*envp && ft_strncmp(*envp, "PATH=", 5) != 0)
-		envp++;
-	if (!*envp)
+	path_value = hashtable_get(env->vars, "PATH");
+	if (!path_value)
 	{
-		default_paths = ft_calloc(6, sizeof(char *));
-		if (!default_paths)
-			return (NULL);
-		default_paths[0] = ft_strdup("/usr/local/bin");
-		default_paths[1] = ft_strdup("/usr/bin");
-		default_paths[2] = ft_strdup("/bin");
-		default_paths[3] = ft_strdup("/usr/sbin");
-		default_paths[4] = ft_strdup("/sbin");
-		default_paths[5] = NULL;
-		return (default_paths);
+		empty_paths = ft_calloc(1, sizeof(char *));
+		return (empty_paths);
 	}
-	return (ft_split(*envp + 5, ':'));
+	return (ft_split(path_value, ':'));
 }
 
 int	check_path(char *path, char *argv)

--- a/src/eval/cmd_res.c
+++ b/src/eval/cmd_res.c
@@ -26,11 +26,6 @@ t_cmd_response	*create_cmd_res(void)
 
 void	*destroy_cmd_res(t_cmd_response *cmd_res)
 {
-	if (cmd_res->curr_dir)
-	{
-		free(cmd_res->curr_dir);
-		cmd_res->curr_dir = NULL;
-	}
 	free(cmd_res);
 	cmd_res = NULL;
 	return (cmd_res);

--- a/src/eval/eval.c
+++ b/src/eval/eval.c
@@ -16,91 +16,75 @@
 #include "minishell_signal.h"
 #include <fcntl.h>
 #include <stdlib.h>
-#include <readline/readline.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
-void	exec_child_cmd(t_ast *ast, t_cmd_func_call *call)
+static t_cmd_response	*handle_no_cmd_name(t_ast *shell_ast, t_shell_env *env)
 {
-	t_cmd_response	*cmd_res;
-	t_shell_env		*env;
-	int				code;
-
-	code = 1;
-	env = call->env;
-	setup_fork_signal(0);
-	cmd_res = call->cmd_func(ast, call->cmd_str, call->env);
-	if (cmd_res)
-	{
-		code = cmd_res->exit_code;
-		destroy_cmd_res(cmd_res);
-	}
-	free_cmd_str(call->cmd_str);
-	free(call);
-	child_exit(env, ast, code);
-}
-
-t_cmd_response	*eval_external_cmd(t_ast *shell_ast, t_cmd_func_call *call)
-{
-	pid_t			cmd_pid;
 	t_cmd_response	*res;
 
-	cmd_pid = fork();
-	if (cmd_pid == -1)
-		return (NULL);
-	if (cmd_pid == 0)
-		exec_child_cmd(shell_ast, call);
-	setup_fork_signal(cmd_pid);
-	res = handle_parent(cmd_pid);
-	setup_nonfork_signal();
+	save_original_std_fds(env);
+	res = create_cmd_res();
+	if (res)
+	{
+		res->exit_code = 1;
+		if (eval_redir(shell_ast) > 0)
+			res->exit_code = 0;
+	}
+	restore_original_std_fds(env);
 	return (res);
 }
 
-t_cmd_response	*eval_cmd(t_ast *shell_ast, t_shell_env *env)
+static t_cmd_response	*exec_cmd_with_call(t_ast *ast, t_cmd_func_call *call,
+							t_shell_env *env)
 {
-	t_cmd_response		*res;
-	t_cmd_func_call		*call;
+	t_cmd_response	*res;
 
+	(void)env;
 	res = NULL;
-	call = check_cmd(shell_ast, env);
-	if (!call)
-		return (NULL);
-	save_original_std_fds(env);
-	if (eval_redir(shell_ast) > 0)
-		res = exec_call(shell_ast, call);
+	if (eval_redir(ast) > 0)
+		res = exec_call(ast, call);
 	else
 	{
 		res = create_cmd_res();
 		if (res)
 			res->exit_code = 1;
 	}
+	return (res);
+}
+
+t_cmd_response	*eval_cmd(t_ast *shell_ast, t_shell_env *env)
+{
+	t_cmd_response	*res;
+	t_cmd_func_call	*call;
+
+	if (!shell_ast->u_ast.s_simple_cmd.cmd_name)
+		return (handle_no_cmd_name(shell_ast, env));
+	call = check_cmd(shell_ast, env);
+	if (!call)
+		return (NULL);
+	if (env)
+		env->current_call = call;
+	save_original_std_fds(env);
+	res = exec_cmd_with_call(shell_ast, call, env);
 	restore_original_std_fds(env);
 	free_cmd_str(call->cmd_str);
+	if (env)
+		env->current_call = NULL;
 	free(call);
 	return (res);
 }
 
-t_cmd_response	*eval_pipe(t_ast *shell_ast, t_shell_env *env)
+static t_cmd_response	*eval_node(t_ast *node, t_shell_env *env)
 {
-	pid_t			root_pid;
-	t_cmd_response	*res;
-
-	if (shell_ast->type == AST_SIMPLE_CMD)
-		return (eval_cmd(shell_ast, env));
-	root_pid = fork();
-	if (root_pid == -1)
-		return (NULL);
-	if (root_pid == 0)
-	{
-		setup_fork_signal(0);
-		eval_pipe_recursive(shell_ast, env, NULL, -1);
-		child_exit(env, shell_ast, 1);
-	}
-	setup_fork_signal(root_pid);
-	res = handle_parent(root_pid);
-	setup_nonfork_signal();
-	return (res);
+	if (node->type == AST_SIMPLE_CMD)
+		return (eval_cmd(node, env));
+	else if (node->type == AST_PIPE_SEQ)
+		return (eval_pipe(node, env));
+	else if (node->type == AST_AND_OR)
+		return (eval_and_or(node, env));
+	else if (node->type == AST_SUBSHELL)
+		return (eval_subshell(node, env));
+	return (NULL);
 }
 
 t_shell_response	*eval_ast(t_ast *shell_ast, t_shell_env *env)
@@ -108,18 +92,14 @@ t_shell_response	*eval_ast(t_ast *shell_ast, t_shell_env *env)
 	t_shell_response	*res;
 	t_cmd_response		*cmd_res;
 
-	if (env)
-		env->root_node = shell_ast;
+	if (!shell_ast)
+		return (NULL);
 	if (process_heredocs(shell_ast, env) == -1)
 	{
 		cleanup_heredoc_files(shell_ast);
 		return (NULL);
 	}
-	cmd_res = NULL;
-	if (shell_ast->type == AST_SIMPLE_CMD)
-		cmd_res = eval_cmd(shell_ast, env);
-	else if (shell_ast->type == AST_PIPE_SEQ)
-		cmd_res = eval_pipe(shell_ast, env);
+	cmd_res = eval_node(shell_ast, env);
 	cleanup_heredoc_files(shell_ast);
 	if (!cmd_res)
 		return (NULL);
@@ -127,7 +107,8 @@ t_shell_response	*eval_ast(t_ast *shell_ast, t_shell_env *env)
 	if (!res)
 		return (destroy_cmd_res(cmd_res));
 	res->exit_code = cmd_res->exit_code;
-	res->curr_dir = cmd_res->curr_dir;
+	if (env)
+		env->last_exit_code = res->exit_code;
 	free(cmd_res);
 	return (res);
 }

--- a/src/eval/eval_helpers.c
+++ b/src/eval/eval_helpers.c
@@ -1,0 +1,61 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   eval_helpers.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hermarti <hermarti@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/03 12:00:00 by hermarti          #+#    #+#             */
+/*   Updated: 2026/02/03 12:00:00 by hermarti         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ast.h"
+#include "eval.h"
+#include "minishell_signal.h"
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+void	exec_child_cmd(t_ast *ast, t_cmd_func_call *call)
+{
+	t_cmd_response	*cmd_res;
+	t_shell_env		*env;
+	int				code;
+
+	code = 1;
+	env = call->env;
+	setup_fork_signal(0);
+	if (env)
+	{
+		env->interactive_owner = 0;
+		env->current_call = call;
+	}
+	cmd_res = call->cmd_func(ast, call->cmd_str, call->env);
+	if (cmd_res)
+	{
+		code = cmd_res->exit_code;
+		destroy_cmd_res(cmd_res);
+	}
+	free_cmd_str(call->cmd_str);
+	free(call);
+	if (env)
+		env->current_call = NULL;
+	child_exit(env, ast, code);
+}
+
+t_cmd_response	*eval_external_cmd(t_ast *shell_ast, t_cmd_func_call *call)
+{
+	pid_t			cmd_pid;
+	t_cmd_response	*res;
+
+	cmd_pid = fork();
+	if (cmd_pid == -1)
+		return (NULL);
+	if (cmd_pid == 0)
+		exec_child_cmd(shell_ast, call);
+	setup_fork_signal(cmd_pid);
+	res = handle_parent(cmd_pid);
+	setup_nonfork_signal();
+	return (res);
+}

--- a/src/eval/eval_nodes.c
+++ b/src/eval/eval_nodes.c
@@ -1,0 +1,124 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   eval_nodes.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hermarti <hermarti@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/03 12:00:00 by hermarti          #+#    #+#             */
+/*   Updated: 2026/02/03 12:00:00 by hermarti         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ast.h"
+#include "eval.h"
+#include "minishell_signal.h"
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+t_cmd_response	*eval_pipe(t_ast *shell_ast, t_shell_env *env)
+{
+	pid_t			root_pid;
+	t_cmd_response	*res;
+
+	if (shell_ast->type == AST_SIMPLE_CMD)
+		return (eval_cmd(shell_ast, env));
+	root_pid = fork();
+	if (root_pid == -1)
+		return (NULL);
+	if (root_pid == 0)
+	{
+		setup_fork_signal(0);
+		if (env)
+			env->interactive_owner = 0;
+		eval_pipe_recursive(shell_ast, env, NULL, -1);
+		child_exit(env, shell_ast, 1);
+	}
+	setup_fork_signal(root_pid);
+	res = handle_parent(root_pid);
+	setup_nonfork_signal();
+	return (res);
+}
+
+static void	subshell_child(t_ast *shell_ast, t_shell_env *env)
+{
+	t_shell_response	*sub_res;
+	int					code;
+
+	setup_fork_signal(0);
+	if (env)
+		env->interactive_owner = 0;
+	sub_res = eval_ast(shell_ast->u_ast.s_subshell.and_or, env);
+	code = 0;
+	if (sub_res)
+		code = sub_res->exit_code;
+	if (sub_res)
+		free(sub_res);
+	child_exit(env, shell_ast, code);
+}
+
+t_cmd_response	*eval_subshell(t_ast *shell_ast, t_shell_env *env)
+{
+	pid_t			pid;
+	int				status;
+	t_cmd_response	*cmd_res;
+
+	if (!shell_ast)
+		return (NULL);
+	pid = fork();
+	if (pid == -1)
+		return (NULL);
+	if (pid == 0)
+		subshell_child(shell_ast, env);
+	setup_fork_signal(pid);
+	waitpid(pid, &status, 0);
+	setup_nonfork_signal();
+	cmd_res = create_cmd_res();
+	if (!cmd_res)
+		return (NULL);
+	if (WIFEXITED(status))
+		cmd_res->exit_code = WEXITSTATUS(status);
+	else if (WIFSIGNALED(status))
+		cmd_res->exit_code = 128 + WTERMSIG(status);
+	return (cmd_res);
+}
+
+static t_cmd_response	*eval_node(t_ast *node, t_shell_env *env)
+{
+	if (node->type == AST_SIMPLE_CMD)
+		return (eval_cmd(node, env));
+	else if (node->type == AST_PIPE_SEQ)
+		return (eval_pipe(node, env));
+	else if (node->type == AST_AND_OR)
+		return (eval_and_or(node, env));
+	else if (node->type == AST_SUBSHELL)
+		return (eval_subshell(node, env));
+	return (NULL);
+}
+
+t_cmd_response	*eval_and_or(t_ast *shell_ast, t_shell_env *env)
+{
+	t_cmd_response	*left_res;
+	t_cmd_response	*right_res;
+	t_ast			*left;
+	t_ast			*right;
+	t_token_type	op_type;
+
+	if (!shell_ast)
+		return (NULL);
+	left = shell_ast->u_ast.s_and_or.left;
+	right = shell_ast->u_ast.s_and_or.right;
+	left_res = eval_node(left, env);
+	if (!left_res)
+		return (NULL);
+	op_type = shell_ast->u_ast.s_and_or.op->type;
+	if ((op_type == AND_IF && left_res->exit_code == 0)
+		|| (op_type == OR_IF && left_res->exit_code != 0))
+	{
+		right_res = eval_node(right, env);
+		destroy_cmd_res(left_res);
+		return (right_res);
+	}
+	return (left_res);
+}

--- a/src/eval/eval_util.c
+++ b/src/eval/eval_util.c
@@ -10,8 +10,8 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "libft.h"
 #include "eval.h"
+#include "libft.h"
 #include <unistd.h>
 
 t_cmd_func_call	*check_cmd(t_ast *shell_ast, t_shell_env *env)
@@ -22,9 +22,11 @@ t_cmd_func_call	*check_cmd(t_ast *shell_ast, t_shell_env *env)
 	if (!call)
 		return (NULL);
 	call->env = env;
+	if (env)
+		env->current_call = call;
 	call->envp = env->envp;
 	call->cmd_str = get_cmd_str(shell_ast->u_ast.s_simple_cmd.cmd_name,
-			shell_ast->u_ast.s_simple_cmd.cmd_suffix, env->envp);
+			shell_ast->u_ast.s_simple_cmd.cmd_suffix, env);
 	call->cmd_func = get_cmd_func(shell_ast->u_ast.s_simple_cmd.cmd_name);
 	call->is_builtin = check_builtin(shell_ast->u_ast.s_simple_cmd.cmd_name);
 	return (call);

--- a/src/eval/pipe/child_parent.c
+++ b/src/eval/pipe/child_parent.c
@@ -10,10 +10,14 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "ast.h"
 #include "eval.h"
+#include <readline/readline.h>
+#include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <string.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 void	save_original_std_fds(t_shell_env *env)
 {
@@ -40,16 +44,17 @@ void	restore_original_std_fds(t_shell_env *env)
 void	child_exit(t_shell_env *env, t_ast *local_ast, int code)
 {
 	if (env && env->root_node)
-		free_ast(env->root_node);
-	else if (local_ast)
-		free_ast(local_ast);
-	if (env)
 	{
-		close(env->og_stdout_fd);
-		close(env->og_stdin_fd);
 		destroy_shell_env(env);
 	}
-	exit(code);
+	else
+	{
+		if (local_ast)
+			free_ast(local_ast);
+		if (env)
+			destroy_shell_env(env);
+	}
+	exit((unsigned char)code);
 }
 
 t_cmd_response	*handle_parent(pid_t pid)

--- a/src/eval/pipe/pipe.c
+++ b/src/eval/pipe/pipe.c
@@ -13,63 +13,81 @@
 #include "ast.h"
 #include "eval.h"
 #include <stdlib.h>
-#include <unistd.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
-void	run_pipe_child(t_ast *ast, t_shell_env *env, t_pipe_context *ctx)
-{
-	if (ctx->writer)
-	{
-		close(ctx->writer[INPUT_END]);
-		if (dup2(ctx->writer[OUTPUT_END], STDOUT_FILENO) == -1)
-			exit(EXIT_FAILURE);
-		close(ctx->writer[OUTPUT_END]);
-		eval_pipe_recursive(ast->u_ast.s_pipe_seq.left, env, ctx->writer,
-			ctx->prev_pipe_fd_read_end);
-	}
-	else
-	{
-		close(ctx->reader[OUTPUT_END]);
-		if (dup2(ctx->reader[INPUT_END], STDIN_FILENO) == -1)
-			exit(EXIT_FAILURE);
-		close(ctx->reader[INPUT_END]);
-		eval_pipe_recursive(ast->u_ast.s_pipe_seq.right, env, NULL,
-			ctx->prev_pipe_fd_read_end);
-	}
-}
-
-static void	handle_child_process(t_ast *ast, t_shell_env *env,
-				int *pipe_fd, int *new_fd)
+static void	handle_child_process(t_ast *ast, t_shell_env *env, int *pipe_fd,
+		int *new_fd)
 {
 	t_pipe_context	ctx;
 
+	if (env)
+		env->interactive_owner = 0;
 	if (pipe_fd)
 		close(pipe_fd[INPUT_END]);
 	close(new_fd[INPUT_END]);
-	ctx = (t_pipe_context){new_fd, NULL, -1};
+	ctx = (t_pipe_context){new_fd, NULL, -1, 0};
 	run_pipe_child(ast, env, &ctx);
+}
+
+static void	wait_and_exit(t_ast *ast, t_shell_env *env, pid_t left, pid_t right)
+{
+	int	status;
+
+	waitpid(left, &status, 0);
+	waitpid(right, &status, 0);
+	if (WIFEXITED(status))
+		child_exit(env, ast, WEXITSTATUS(status));
+	else if (WIFSIGNALED(status))
+		child_exit(env, ast, 128 + WTERMSIG(status));
+	child_exit(env, ast, EXIT_FAILURE);
 }
 
 static void	handle_parent_process(t_ast *ast, t_shell_env *env,
-				int *pipe_fd, int *new_fd)
+		t_pipe_context *ctx)
 {
-	t_pipe_context	ctx;
-	int				prev_pipe_read_fd;
+	t_pipe_context	child_ctx;
+	int				status;
+	pid_t			right_pid;
 
-	close(new_fd[OUTPUT_END]);
-	prev_pipe_read_fd = -1;
+	close(ctx->writer[OUTPUT_END]);
+	right_pid = fork();
+	if (right_pid == -1)
+	{
+		waitpid(ctx->left_pid, &status, 0);
+		child_exit(env, ast, EXIT_FAILURE);
+	}
+	if (right_pid == 0)
+	{
+		child_ctx = (t_pipe_context){NULL, ctx->writer,
+			ctx->prev_pipe_fd_read_end, 0};
+		run_pipe_child(ast, env, &child_ctx);
+		child_exit(env, ast, EXIT_FAILURE);
+	}
+	close(ctx->writer[INPUT_END]);
+	wait_and_exit(ast, env, ctx->left_pid, right_pid);
+}
+
+static void	init_parent_ctx(t_pipe_context *ctx, int *new_fd, int *pipe_fd,
+							pid_t left_pid)
+{
+	ctx->writer = new_fd;
+	ctx->reader = NULL;
+	ctx->prev_pipe_fd_read_end = -1;
 	if (pipe_fd)
-		prev_pipe_read_fd = pipe_fd[INPUT_END];
-	ctx = (t_pipe_context){NULL, new_fd, prev_pipe_read_fd};
-	run_pipe_child(ast, env, &ctx);
+		ctx->prev_pipe_fd_read_end = pipe_fd[INPUT_END];
+	ctx->left_pid = left_pid;
 }
 
 void	eval_pipe_recursive(t_ast *ast, t_shell_env *env, int *pipe_fd,
-						int prev_pipe_read_fd)
+		int prev_pipe_read_fd)
 {
+	t_pipe_context	ctx;
 	pid_t			left_pid;
 	int				new_fd[2];
 
+	(void)prev_pipe_read_fd;
 	if (ast->type == AST_SIMPLE_CMD)
 		func_exec_cmd_pipe(ast, env, pipe_fd, prev_pipe_read_fd);
 	if (ast->type != AST_PIPE_SEQ || pipe(new_fd) == -1)
@@ -78,8 +96,10 @@ void	eval_pipe_recursive(t_ast *ast, t_shell_env *env, int *pipe_fd,
 	if (left_pid == -1)
 		child_exit(env, ast, EXIT_FAILURE);
 	if (left_pid == 0)
+	{
 		handle_child_process(ast, env, pipe_fd, new_fd);
-	else
-		handle_parent_process(ast, env, pipe_fd, new_fd);
-	child_exit(env, ast, EXIT_FAILURE);
+		child_exit(env, ast, EXIT_FAILURE);
+	}
+	init_parent_ctx(&ctx, new_fd, pipe_fd, left_pid);
+	handle_parent_process(ast, env, &ctx);
 }

--- a/src/eval/pipe/pipe_exec.c
+++ b/src/eval/pipe/pipe_exec.c
@@ -38,13 +38,44 @@ static void	close_prev_and_pipe_fds(int pipe_fd[2], int prev_pipe_read_fd)
 		close(prev_pipe_read_fd);
 }
 
+static void	cleanup_and_exit(t_ast *ast, t_shell_env *env,
+				t_cmd_func_call *call, int code)
+{
+	free_cmd_str(call->cmd_str);
+	if (env)
+		env->current_call = NULL;
+	free(call);
+	child_exit(env, ast, code);
+}
+
+void	run_pipe_child(t_ast *ast, t_shell_env *env, t_pipe_context *ctx)
+{
+	if (ctx->writer)
+	{
+		close(ctx->writer[INPUT_END]);
+		if (dup2(ctx->writer[OUTPUT_END], STDOUT_FILENO) == -1)
+			exit(EXIT_FAILURE);
+		close(ctx->writer[OUTPUT_END]);
+		eval_pipe_recursive(ast->u_ast.s_pipe_seq.left, env, ctx->writer,
+			ctx->prev_pipe_fd_read_end);
+	}
+	else
+	{
+		close(ctx->reader[OUTPUT_END]);
+		if (dup2(ctx->reader[INPUT_END], STDIN_FILENO) == -1)
+			exit(EXIT_FAILURE);
+		close(ctx->reader[INPUT_END]);
+		eval_pipe_recursive(ast->u_ast.s_pipe_seq.right, env, NULL,
+			ctx->prev_pipe_fd_read_end);
+	}
+}
+
 void	func_exec_cmd_pipe(t_ast *ast, t_shell_env *env, int *pipe_fd,
 						int prev_pipe_read_fd)
 {
 	int				exit_code;
 	t_cmd_func_call	*call;
 
-	exit_code = 1;
 	if (ast->type != AST_SIMPLE_CMD)
 		child_exit(env, ast, 1);
 	call = check_cmd(ast, env);
@@ -53,15 +84,9 @@ void	func_exec_cmd_pipe(t_ast *ast, t_shell_env *env, int *pipe_fd,
 	if (!call->is_builtin)
 		close_prev_and_pipe_fds(pipe_fd, prev_pipe_read_fd);
 	if (eval_redir(ast) == -1)
-	{
-		free_cmd_str(call->cmd_str);
-		free(call);
-		child_exit(env, ast, 1);
-	}
+		cleanup_and_exit(ast, env, call, 1);
 	exit_code = execute_child_cmd_pipe(call, ast);
 	if (call->is_builtin)
 		close_prev_and_pipe_fds(pipe_fd, prev_pipe_read_fd);
-	free_cmd_str(call->cmd_str);
-	free(call);
-	child_exit(env, ast, exit_code);
+	cleanup_and_exit(ast, env, call, exit_code);
 }

--- a/src/eval/redir/here_doc.c
+++ b/src/eval/redir/here_doc.c
@@ -13,34 +13,39 @@
 #include "ast.h"
 #include "eval.h"
 #include "libft.h"
-#include <readline/readline.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-static int	handle_io(t_ast *io)
-{
-	char	*temp_file;
+int	handle_heredoc_io(t_ast *io);
 
-	if (io && io->u_ast.s_io_file.op->type == DLESS)
+static int	process_simple_cmd_heredocs(t_ast *node)
+{
+	t_ast	*it;
+
+	it = node->u_ast.s_simple_cmd.cmd_prefix;
+	while (it)
 	{
-		temp_file = generate_heredoc_filename();
-		if (write_heredoc_to_file((char *)io->u_ast.s_io_file.filename,
-				temp_file) == -1)
-		{
-			free(temp_file);
-			return (-1);
-		}
-		io->u_ast.s_io_file.op->type = LESS;
-		io->u_ast.s_io_file.filename = temp_file;
+		if (it->type == AST_CMD_PREFIX && it->u_ast.s_cmd_prefix.io_file
+			&& it->u_ast.s_cmd_prefix.io_file->type == AST_IO_FILE)
+			if (handle_heredoc_io(it->u_ast.s_cmd_prefix.io_file) == -1)
+				return (-1);
+		it = it->u_ast.s_cmd_prefix.cmd_prefix;
+	}
+	it = node->u_ast.s_simple_cmd.cmd_suffix;
+	while (it)
+	{
+		if (it->type == AST_CMD_SUFFIX && it->u_ast.s_cmd_suffix.io_file
+			&& it->u_ast.s_cmd_suffix.io_file->type == AST_IO_FILE)
+			if (handle_heredoc_io(it->u_ast.s_cmd_suffix.io_file) == -1)
+				return (-1);
+		it = it->u_ast.s_cmd_suffix.cmd_suffix;
 	}
 	return (0);
 }
 
 int	process_heredocs(t_ast *node, t_shell_env *env)
 {
-	t_ast	*tmp;
-
 	if (!node)
 		return (0);
 	if (node->type == AST_PIPE_SEQ)
@@ -49,20 +54,16 @@ int	process_heredocs(t_ast *node, t_shell_env *env)
 			return (-1);
 		return (process_heredocs(node->u_ast.s_pipe_seq.right, env));
 	}
-	tmp = node->u_ast.s_simple_cmd.cmd_prefix;
-	while (node->type == AST_SIMPLE_CMD && tmp)
+	if (node->type == AST_AND_OR || node->type == AST_LIST)
 	{
-		if (handle_io(tmp->u_ast.s_cmd_prefix.io_file) == -1)
+		if (process_heredocs(node->u_ast.s_and_or.left, env) == -1)
 			return (-1);
-		tmp = tmp->u_ast.s_cmd_prefix.cmd_prefix;
+		return (process_heredocs(node->u_ast.s_and_or.right, env));
 	}
-	tmp = node->u_ast.s_simple_cmd.cmd_suffix;
-	while (node->type == AST_SIMPLE_CMD && tmp)
-	{
-		if (handle_io(tmp->u_ast.s_cmd_suffix.io_file) == -1)
-			return (-1);
-		tmp = tmp->u_ast.s_cmd_suffix.cmd_suffix;
-	}
+	if (node->type == AST_SUBSHELL)
+		return (process_heredocs(node->u_ast.s_subshell.and_or, env));
+	if (node->type == AST_SIMPLE_CMD)
+		return (process_simple_cmd_heredocs(node));
 	return (0);
 }
 
@@ -87,10 +88,26 @@ static void	unlink_heredoc_node(t_ast *node)
 	}
 }
 
-void	cleanup_heredoc_files(t_ast *ast)
+static void	cleanup_simple_cmd_heredocs(t_ast *ast)
 {
 	t_ast	*curr;
 
+	curr = ast->u_ast.s_simple_cmd.cmd_prefix;
+	while (curr)
+	{
+		unlink_heredoc_node(curr->u_ast.s_cmd_prefix.io_file);
+		curr = curr->u_ast.s_cmd_prefix.cmd_prefix;
+	}
+	curr = ast->u_ast.s_simple_cmd.cmd_suffix;
+	while (curr)
+	{
+		unlink_heredoc_node(curr->u_ast.s_cmd_suffix.io_file);
+		curr = curr->u_ast.s_cmd_suffix.cmd_suffix;
+	}
+}
+
+void	cleanup_heredoc_files(t_ast *ast)
+{
 	if (!ast)
 		return ;
 	if (ast->type == AST_PIPE_SEQ)
@@ -98,19 +115,13 @@ void	cleanup_heredoc_files(t_ast *ast)
 		cleanup_heredoc_files(ast->u_ast.s_pipe_seq.left);
 		cleanup_heredoc_files(ast->u_ast.s_pipe_seq.right);
 	}
-	else if (ast->type == AST_SIMPLE_CMD)
+	else if (ast->type == AST_AND_OR || ast->type == AST_LIST)
 	{
-		curr = ast->u_ast.s_simple_cmd.cmd_prefix;
-		while (curr)
-		{
-			unlink_heredoc_node(curr->u_ast.s_cmd_prefix.io_file);
-			curr = curr->u_ast.s_cmd_prefix.cmd_prefix;
-		}
-		curr = ast->u_ast.s_simple_cmd.cmd_suffix;
-		while (curr)
-		{
-			unlink_heredoc_node(curr->u_ast.s_cmd_suffix.io_file);
-			curr = curr->u_ast.s_cmd_suffix.cmd_suffix;
-		}
+		cleanup_heredoc_files(ast->u_ast.s_and_or.left);
+		cleanup_heredoc_files(ast->u_ast.s_and_or.right);
 	}
+	else if (ast->type == AST_SUBSHELL)
+		cleanup_heredoc_files(ast->u_ast.s_subshell.and_or);
+	else if (ast->type == AST_SIMPLE_CMD)
+		cleanup_simple_cmd_heredocs(ast);
 }

--- a/src/eval/redir/here_doc_write.c
+++ b/src/eval/redir/here_doc_write.c
@@ -10,6 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "ast.h"
 #include "eval.h"
 #include "libft.h"
 #include "minishell_signal.h"
@@ -43,5 +44,24 @@ int	write_heredoc_to_file(char *delimiter, char *filename)
 	close(fd);
 	if (g_sig == SIGINT)
 		return (-1);
+	return (0);
+}
+
+int	handle_heredoc_io(t_ast *io)
+{
+	char	*temp_file;
+
+	if (io && io->u_ast.s_io_file.op->type == DLESS)
+	{
+		temp_file = generate_heredoc_filename();
+		if (write_heredoc_to_file((char *)io->u_ast.s_io_file.filename,
+				temp_file) == -1)
+		{
+			free(temp_file);
+			return (-1);
+		}
+		io->u_ast.s_io_file.op->type = LESS;
+		io->u_ast.s_io_file.filename = temp_file;
+	}
 	return (0);
 }

--- a/src/eval/shell_env/shell_env.c
+++ b/src/eval/shell_env/shell_env.c
@@ -10,20 +10,36 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "ast.h"
 #include "eval.h"
 #include "hashtable.h"
+#include <readline/readline.h>
 #include <stdlib.h>
+#include <unistd.h>
+
+static void	parse_env_var(t_shell_env *env, char *env_str)
+{
+	char	*tmp_var;
+	char	*after_equal;
+
+	tmp_var = ft_strdup(env_str);
+	after_equal = ft_strchr(tmp_var, '=');
+	*after_equal = '\0';
+	hashtable_set(env->vars, tmp_var, ft_strdup(after_equal + 1));
+	ft_lstadd_back(&env->order, ft_lstnew(ft_strdup(tmp_var)));
+	free(tmp_var);
+}
 
 t_shell_env	*create_shell_env(char *envp[])
 {
-	char		*tmp_var;
-	char		*after_equal;
 	t_shell_env	*env;
 	size_t		i;
 
 	env = ft_calloc(1, sizeof(t_shell_env));
 	if (!env)
 		return (NULL);
+	if (isatty(STDIN_FILENO))
+		env->interactive_owner = 1;
 	env->vars = hashtable_create();
 	if (!env->vars)
 		return (free(env), NULL);
@@ -31,25 +47,70 @@ t_shell_env	*create_shell_env(char *envp[])
 	i = 0;
 	while (envp[i])
 	{
-		tmp_var = ft_strdup(envp[i]);
-		after_equal = ft_strchr(tmp_var, '=');
-		*after_equal = '\0';
-		hashtable_set(env->vars, tmp_var, ft_strdup(after_equal + 1));
-		ft_lstadd_back(&env->order, ft_lstnew(ft_strdup(tmp_var)));
-		free(tmp_var);
+		parse_env_var(env, envp[i]);
 		i++;
 	}
 	return (env);
+}
+
+static void	destroy_env_resources(t_shell_env *env)
+{
+	if (env->og_stdin_fd > 2)
+		close(env->og_stdin_fd);
+	if (env->og_stdout_fd > 2)
+		close(env->og_stdout_fd);
+	if (env->current_input)
+	{
+		free(env->current_input);
+		env->current_input = NULL;
+	}
+	if (env->current_call)
+	{
+		free_cmd_str(env->current_call->cmd_str);
+		env->current_call->cmd_str = NULL;
+		free(env->current_call);
+		env->current_call = NULL;
+	}
+}
+
+static void	destroy_env_parser(t_shell_env *env)
+{
+	if (env->root_node)
+	{
+		free_ast(env->root_node);
+		env->root_node = NULL;
+	}
+	if (env->parser)
+	{
+		free(env->parser);
+		env->parser = NULL;
+	}
+	if (env->lexer)
+	{
+		if (env->lexer->tokens)
+			ft_lstclear(&(env->lexer->tokens), &free_token);
+		free(env->lexer);
+		env->lexer = NULL;
+	}
 }
 
 void	*destroy_shell_env(t_shell_env *env)
 {
 	if (!env)
 		return (NULL);
+	destroy_env_resources(env);
+	destroy_env_parser(env);
 	if (env->vars)
+	{
 		hashtable_destroy(env->vars);
+		env->vars = NULL;
+	}
 	if (env->order)
+	{
 		ft_lstclear(&env->order, free);
+		env->order = NULL;
+	}
+	rl_clear_history();
 	free(env);
 	return (NULL);
 }

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -53,7 +53,7 @@ void	check_operators(t_lexer *lexer, t_token *token)
 {
 	int					i;
 	int					size;
-	const t_hash_item	operators[] = {{"", END}, {"=", EQUAL},
+	const t_hash_item	operators[] = {{"", NEWLINE}, {"=", EQUAL},
 	{"(", LPAREN}, {")", RPAREN}};
 
 	check_duplicate_operators(lexer, token);
@@ -67,6 +67,9 @@ void	check_operators(t_lexer *lexer, t_token *token)
 			{
 				*token = (t_token){operators[i].value, operators[i].key,
 					CHAR_SIZE};
+				if (operators[i].value == NEWLINE)
+					*token = (t_token){operators[i].value, "newline",
+					ft_strlen("newline")};
 			}
 			i++;
 		}

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -13,11 +13,10 @@
 #include "lexer.h"
 #include "libft.h"
 
-void	set_operators(t_hash_item operator, char ch, t_token *token,
-		int idx)
+void	set_operators(t_hash_item operator, char ch, t_token *token, int idx)
 {
-	const t_hash_item	dup_operators[] = {{"||", OR_IF}, {"&&", AND_IF},
-	{"<<", DLESS}, {">>", DGREAT}};
+	const t_hash_item	dup_operators[] = {{"||", OR_IF}, {"&&", AND_IF}, {"<<",
+		DLESS}, {">>", DGREAT}};
 
 	if (ch == *(operator.key))
 	{
@@ -32,8 +31,8 @@ void	check_duplicate_operators(t_lexer *lexer, t_token *token)
 {
 	int					i;
 	int					size;
-	const t_hash_item	operators[] = {{"|", PIPE}, {"&", AMPERSAND},
-	{"<", LESS}, {">", GREAT}, {";", ILLEGAL}};
+	const t_hash_item	operators[] = {{"|", PIPE}, {"&", AMPERSAND}, {"<",
+		LESS}, {">", GREAT}, {";", ILLEGAL}};
 
 	i = 0;
 	size = sizeof(operators) / sizeof(t_hash_item);
@@ -53,8 +52,8 @@ void	check_operators(t_lexer *lexer, t_token *token)
 {
 	int					i;
 	int					size;
-	const t_hash_item	operators[] = {{"", NEWLINE}, {"=", EQUAL},
-	{"(", LPAREN}, {")", RPAREN}};
+	const t_hash_item	operators[] = {{"", NEWLINE}, {"=", EQUAL}, {"(",
+		LPAREN}, {")", RPAREN}};
 
 	check_duplicate_operators(lexer, token);
 	if (token->literal == NULL)
@@ -69,7 +68,7 @@ void	check_operators(t_lexer *lexer, t_token *token)
 					CHAR_SIZE};
 				if (operators[i].value == NEWLINE)
 					*token = (t_token){operators[i].value, "newline",
-					ft_strlen("newline")};
+						ft_strlen("newline")};
 			}
 			i++;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -11,59 +11,15 @@
 /* ************************************************************************** */
 
 #include "eval.h"
-#include "lexer.h"
 #include "libft.h"
 #include "minishell.h"
-#include "parser.h"
 #include "minishell_signal.h"
-#include <unistd.h>
-#include <stdio.h>
 #include <readline/history.h>
 #include <readline/readline.h>
 #include <stdlib.h>
+#include <unistd.h>
 
-int	create_lexer_parser(char *input, t_lexer **lexer, t_parser **parser)
-{
-	*lexer = create_lexer(input);
-	if (lexer == NULL)
-	{
-		ft_printf("Failed to create lexer\n");
-		return (-1);
-	}
-	*parser = create_parser(*lexer);
-	if (parser == NULL)
-	{
-		ft_printf("Failed to create parser\n");
-		free(*lexer);
-		return (-1);
-	}
-	return (0);
-}
-
-void	parse_input(char *input, t_shell_env *env)
-{
-	t_shell_response	*res;
-	t_lexer				*lexer;
-	t_parser			*parser;
-	t_ast				*ast;
-
-	res = NULL;
-	parser = NULL;
-	lexer = NULL;
-	if (create_lexer_parser(input, &lexer, &parser) < 0)
-		return ;
-	ast = init_ast(parser);
-	if (ast)
-	{
-		res = eval_ast(ast, env);
-		if (res)
-			free(res);
-		free_ast(ast);
-	}
-	free(parser);
-	ft_lstclear(&(lexer->tokens), &free_token);
-	free(lexer);
-}
+void	parse_input(char *input, t_shell_env *env);
 
 static int	get_input(t_minishell *shell)
 {
@@ -87,6 +43,18 @@ static int	get_input(t_minishell *shell)
 	return (0);
 }
 
+static void	process_shell_input(t_minishell *shell, t_shell_env *env)
+{
+	env->current_input = shell->input;
+	parse_input(shell->input, env);
+	if (shell->input)
+	{
+		free(shell->input);
+		shell->input = NULL;
+		env->current_input = NULL;
+	}
+}
+
 int	main(int argc, char **argv, char **envp)
 {
 	t_minishell	shell;
@@ -106,9 +74,9 @@ int	main(int argc, char **argv, char **envp)
 			continue ;
 		if (status == -1)
 			break ;
-		parse_input(shell.input, env);
-		free(shell.input);
+		process_shell_input(&shell, env);
 	}
+	status = env->last_exit_code;
 	destroy_shell_env(env);
-	return (EXIT_SUCCESS);
+	return (status);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -40,9 +40,8 @@ int	create_lexer_parser(char *input, t_lexer **lexer, t_parser **parser)
 	return (0);
 }
 
-void	parse_input(char *input, char *envp[])
+void	parse_input(char *input, t_shell_env *env)
 {
-	t_shell_env			*env;
 	t_shell_response	*res;
 	t_lexer				*lexer;
 	t_parser			*parser;
@@ -53,7 +52,6 @@ void	parse_input(char *input, char *envp[])
 	lexer = NULL;
 	if (create_lexer_parser(input, &lexer, &parser) < 0)
 		return ;
-	env = create_shell_env(envp);
 	ast = init_ast(parser);
 	if (ast)
 	{
@@ -62,7 +60,6 @@ void	parse_input(char *input, char *envp[])
 			free(res);
 		free_ast(ast);
 	}
-	destroy_shell_env(env);
 	free(parser);
 	ft_lstclear(&(lexer->tokens), &free_token);
 	free(lexer);
@@ -93,12 +90,14 @@ static int	get_input(t_minishell *shell)
 int	main(int argc, char **argv, char **envp)
 {
 	t_minishell	shell;
+	t_shell_env	*env;
 	int			status;
 
 	(void)argc;
 	(void)argv;
 	ft_memset(&shell, 0, sizeof(t_minishell));
 	setup_nonfork_signal();
+	env = create_shell_env(envp);
 	while (1)
 	{
 		g_sig = 0;
@@ -107,8 +106,9 @@ int	main(int argc, char **argv, char **envp)
 			continue ;
 		if (status == -1)
 			break ;
-		parse_input(shell.input, envp);
+		parse_input(shell.input, env);
 		free(shell.input);
 	}
+	destroy_shell_env(env);
 	return (EXIT_SUCCESS);
 }

--- a/src/parser/parser_input.c
+++ b/src/parser/parser_input.c
@@ -1,0 +1,72 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_input.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hermarti <hermarti@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/03 12:00:00 by hermarti          #+#    #+#             */
+/*   Updated: 2026/02/03 12:00:00 by hermarti         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "eval.h"
+#include "lexer.h"
+#include "libft.h"
+#include "minishell.h"
+#include "parser.h"
+#include <stdlib.h>
+
+static int	create_lexer_parser(char *input, t_shell_env *env)
+{
+	env->lexer = create_lexer(input);
+	if (env->lexer == NULL)
+	{
+		ft_printf("Failed to create lexer\n");
+		return (-1);
+	}
+	env->parser = create_parser(env->lexer);
+	if (env->parser == NULL)
+	{
+		ft_printf("Failed to create parser\n");
+		free(env->lexer);
+		return (-1);
+	}
+	return (0);
+}
+
+static void	cleanup_lexer_parser(t_shell_env *env)
+{
+	if (env->parser)
+	{
+		free(env->parser);
+		env->parser = NULL;
+	}
+	if (env->lexer)
+	{
+		ft_lstclear(&(env->lexer->tokens), &free_token);
+		free(env->lexer);
+		env->lexer = NULL;
+	}
+}
+
+void	parse_input(char *input, t_shell_env *env)
+{
+	t_shell_response	*res;
+	t_ast				*ast;
+
+	res = NULL;
+	if (create_lexer_parser(input, env) < 0)
+		return ;
+	ast = init_ast(env->parser);
+	if (ast)
+	{
+		env->root_node = ast;
+		res = eval_ast(ast, env);
+		if (res)
+			free(res);
+		free_ast(ast);
+		env->root_node = NULL;
+	}
+	cleanup_lexer_parser(env);
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,8 +45,8 @@ TEST_FILES = test_main.c \
 			 $(TEST_EVAL_DIR)/test_eval.c \
 			 $(TEST_EVAL_DIR)/test_eval_pipe.c \
 			 $(TEST_EVAL_DIR)/test_eval_redir.c \
-			 $(TEST_EVAL_DIR)/test_eval_pipe_redir.c
-
+		 $(TEST_EVAL_DIR)/test_eval_pipe_redir.c \
+		 $(TEST_EVAL_DIR)/test_and_or_subshell_eval.c
 
 TEST_OBJ = $(TEST_FILES:%.c=$(TEST_OBJ_DIR)/%.o)
 TEST_BIN = run_tests
@@ -108,10 +108,10 @@ valgrind-single: $(TEST_BIN)
 	@valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=yes ./$(TEST_BIN) $(TEST)
 
 valgrind-log: $(TEST_BIN)
-	@valgrind -q --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=yes --errors-for-leak-kinds=all --error-exitcode=1 --log-file=valgrind.out --suppressions=$(ROOT_DIR)/valgrind.supp ./$(TEST_BIN)
+	@valgrind -q --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=yes --errors-for-leak-kinds=definite,indirect --error-exitcode=1 --log-file=valgrind.out --suppressions=$(ROOT_DIR)/valgrind.supp ./$(TEST_BIN)
 
 valgrind-ci: $(TEST_BIN)
-	@valgrind -q --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=yes --errors-for-leak-kinds=all --error-exitcode=1 --suppressions=$(ROOT_DIR)/valgrind.supp ./$(TEST_BIN)
+	@valgrind -q --leak-check=full --show-leak-kinds=all --track-origins=yes --track-fds=yes --errors-for-leak-kinds=definite,indirect --error-exitcode=1 --suppressions=$(ROOT_DIR)/valgrind.supp ./$(TEST_BIN)
 
 filter: $(TEST_BIN)
 	@CMOCKA_TEST_FILTER="$(FILTER)" ./$(TEST_BIN)

--- a/tests/eval/test_and_or_subshell_eval.c
+++ b/tests/eval/test_and_or_subshell_eval.c
@@ -1,0 +1,409 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   test_and_or_subshell_eval.c                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hermarti <hermarti@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/01/29 14:13:07 by hermarti          #+#    #+#             */
+/*   Updated: 2026/01/29 14:13:11 by hermarti         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ast.h"
+#include "eval.h"
+#include "tests.h"
+#include "test_eval.h"
+#include "lexer.h"
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <cmocka.h>
+#include <linux/limits.h>
+
+static t_ast *make_and_or_ast(t_ast *left, t_token_type op_type, t_ast *right)
+{
+	t_ast	*node;
+	t_token 	tok;
+	t_token	*op;
+
+	node = calloc(1, sizeof(t_ast));
+	if (!node)
+		return (NULL);
+	node->type = AST_AND_OR;
+	node->u_ast.s_and_or.left = left;
+	node->u_ast.s_and_or.right = right;
+	tok = (t_token){op_type, (op_type == AND_IF) ? "&&" : "||", 2};
+	op = create_token(tok);
+	if (!op)
+	{
+		free(node);
+		return (NULL);
+	}
+	node->u_ast.s_and_or.op = op;
+	return (node);
+}
+
+static t_ast *make_subshell_ast(t_ast *inner)
+{
+	t_ast *node;
+
+	node = calloc(1, sizeof(t_ast));
+	if (!node)
+		return (NULL);
+	node->type = AST_SUBSHELL;
+	node->u_ast.s_subshell.and_or = inner;
+	return (node);
+}
+
+/*
+ *   setup: left /bin/true && right echo and_ok
+ */
+int	setup_and_true_and_echo(void **state)
+{
+	t_ast *left = create_cmd_ast("/bin/true", NULL, 0);
+	t_ast *right = create_cmd_ast("echo", (char *[]){"and_ok", NULL}, 1);
+	*state = make_and_or_ast(left, AND_IF, right);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: AND (&&) should run the right side when left returns success
+ */
+void	test_eval_and_runs_right_on_success(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_shell_env *env;
+	t_shell_response *res = NULL;
+	char *captured;
+	extern char **environ;
+
+	assert_non_null(ast);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	captured = eval_and_capture(ast, env, &res);
+	assert_non_null(res);
+	assert_non_null(captured);
+	assert_non_null(strstr(captured, "and_ok"));
+	assert_int_equal(res->exit_code, 0);
+	free(captured);
+	free(res);
+	destroy_shell_env(env);
+}
+
+/*
+ *   setup: left /bin/false && right echo and_should_not
+ */
+int	setup_and_false_and_echo(void **state)
+{
+	t_ast *left = create_cmd_ast("/bin/false", NULL, 0);
+	t_ast *right = create_cmd_ast("echo", (char *[]){"and_should_not", NULL}, 1);
+	*state = make_and_or_ast(left, AND_IF, right);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: AND (&&) should skip the right side when left fails
+ */
+void	test_eval_and_skips_right_on_failure(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_shell_env *env;
+	t_shell_response *res = NULL;
+	char *captured;
+	extern char **environ;
+
+	assert_non_null(ast);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	captured = eval_and_capture(ast, env, &res);
+	assert_non_null(res);
+	assert_non_null(captured);
+	/* should be empty output */
+	assert_int_equal(strlen(captured), 0);
+	assert_int_equal(res->exit_code, 1);
+	free(captured);
+	free(res);
+	destroy_shell_env(env);
+}
+
+/*
+ *   setup: left /bin/false || right echo or_ok
+ */
+int	setup_or_false_or_echo(void **state)
+{
+	t_ast *left = create_cmd_ast("/bin/false", NULL, 0);
+	t_ast *right = create_cmd_ast("echo", (char *[]){"or_ok", NULL}, 1);
+	*state = make_and_or_ast(left, OR_IF, right);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: OR (||) should run the right side when left fails
+ */
+void	test_eval_or_runs_right_on_failure(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_shell_env *env;
+	t_shell_response *res = NULL;
+	char *captured;
+	extern char **environ;
+
+	assert_non_null(ast);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	captured = eval_and_capture(ast, env, &res);
+	assert_non_null(res);
+	assert_non_null(captured);
+	assert_non_null(strstr(captured, "or_ok"));
+	assert_int_equal(res->exit_code, 0);
+	free(captured);
+	free(res);
+	destroy_shell_env(env);
+}
+
+/*
+ *   setup: left /bin/true || right echo or_should_not
+ */
+int	setup_or_true_or_echo(void **state)
+{
+	t_ast *left = create_cmd_ast("/bin/true", NULL, 0);
+	t_ast *right = create_cmd_ast("echo", (char *[]){"or_should_not", NULL}, 1);
+	*state = make_and_or_ast(left, OR_IF, right);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: OR (||) should skip the right side when left succeeds
+ */
+void	test_eval_or_skips_right_on_success(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_shell_env *env;
+	t_shell_response *res = NULL;
+	char *captured;
+	extern char **environ;
+
+	assert_non_null(ast);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	captured = eval_and_capture(ast, env, &res);
+	assert_non_null(res);
+	assert_non_null(captured);
+	/* should be empty output */
+	assert_int_equal(strlen(captured), 0);
+	assert_int_equal(res->exit_code, 0);
+	free(captured);
+	free(res);
+	destroy_shell_env(env);
+}
+
+/*
+ *   setup: subshell that runs `export FOO=bar`
+ */
+int	setup_subshell_export(void **state)
+{
+	t_ast *inner = create_cmd_ast("export", (char *[]){"FOO=bar", NULL}, 1);
+	*state = make_subshell_ast(inner);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: export in subshell should not modify parent environment
+ */
+void	test_subshell_does_not_modify_parent_env(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_ast *env_ast;
+	t_shell_env *env;
+	t_shell_response *res1 = NULL;
+	t_shell_response *res2 = NULL;
+	char *captured1;
+	char *captured2;
+	extern char **environ;
+
+	assert_non_null(ast);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	/* run subshell export */
+	captured1 = eval_and_capture(ast, env, &res1);
+	assert_non_null(res1);
+	/* now run env to ensure FOO is not present */
+	env_ast = create_cmd_ast("env", NULL, 0);
+	captured2 = eval_and_capture(env_ast, env, &res2);
+	assert_non_null(res2);
+	assert_non_null(captured2);
+	/* FOO should not be present in parent env */
+	assert_null(strstr(captured2, "FOO=bar"));
+	free(captured1);
+	free(captured2);
+	free(res1);
+	free(res2);
+	free_cmd_ast(env_ast);
+	destroy_shell_env(env);
+}
+
+/*
+ *   setup: subshell that runs `echo hello`
+ */
+int	setup_subshell_echo(void **state)
+{
+	t_ast *inner = create_cmd_ast("echo", (char *[]){"hello", NULL}, 1);
+	*state = make_subshell_ast(inner);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: echo inside subshell should produce output and exit 0
+ */
+void	test_subshell_echo_outputs_and_exit_zero(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_shell_env *env;
+	t_shell_response *res = NULL;
+	char *captured;
+	extern char **environ;
+
+	assert_non_null(ast);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	captured = eval_and_capture(ast, env, &res);
+	assert_non_null(res);
+	assert_non_null(captured);
+	assert_non_null(strstr(captured, "hello"));
+	assert_int_equal(res->exit_code, 0);
+	free(captured);
+	free(res);
+	destroy_shell_env(env);
+}
+
+/*
+ *   setup: subshell that runs `exit 5`
+ */
+int	setup_subshell_exit_5(void **state)
+{
+	t_ast *inner = create_cmd_ast("exit", (char *[]){"5", NULL}, 1);
+	*state = make_subshell_ast(inner);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: exit in subshell should propagate exit code to parent
+ */
+void	test_subshell_exit_code_propagated(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_shell_env *env;
+	t_shell_response *res = NULL;
+	char *captured;
+	extern char **environ;
+
+	assert_non_null(ast);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	captured = eval_and_capture(ast, env, &res);
+	assert_non_null(res);
+	/* exit 5 should be propagated */
+	assert_int_equal(res->exit_code, 5);
+	free(captured);
+	free(res);
+	destroy_shell_env(env);
+}
+
+/*
+ *   setup: subshell that runs `cd /tmp` (should not change parent cwd)
+ */
+int	setup_subshell_cd(void **state)
+{
+	t_ast *inner = create_cmd_ast("cd", (char *[]){"/tmp", NULL}, 1);
+	*state = make_subshell_ast(inner);
+	if (!*state)
+		return (-1);
+	return (0);
+}
+
+/*
+ *   test: cd inside subshell should not change parent's current directory
+ */
+void	test_subshell_cd_does_not_change_parent_cwd(void **state)
+{
+	t_ast *ast = (t_ast *)(*state);
+	t_shell_env *env;
+	t_shell_response *res = NULL;
+	char *captured;
+	char buf[PATH_MAX + 1];
+	char *cwd_before;
+	extern char **environ;
+
+	assert_non_null(ast);
+	cwd_before = getcwd(buf, PATH_MAX);
+	env = create_shell_env(environ);
+	assert_non_null(env);
+	captured = eval_and_capture(ast, env, &res);
+	assert_non_null(res);
+	assert_string_equal(cwd_before, getcwd(buf, PATH_MAX));
+	free(captured);
+	free(res);
+	destroy_shell_env(env);
+}
+
+/*
+ *   helper: recursively free tokens in AST_AND_OR nodes before calling free_ast
+ *   Tokens in tests are manually created and not owned by a lexer, so we must
+ *   free them explicitly to avoid memory leaks.
+ */
+static void	free_and_or_tokens_recursive(t_ast *ast)
+{
+	if (!ast)
+		return ;
+	if (ast->type == AST_AND_OR)
+	{
+		if (ast->u_ast.s_and_or.op)
+		{
+			free_token(ast->u_ast.s_and_or.op);
+			ast->u_ast.s_and_or.op = NULL;
+		}
+		free_and_or_tokens_recursive(ast->u_ast.s_and_or.left);
+		free_and_or_tokens_recursive(ast->u_ast.s_and_or.right);
+	}
+	else if (ast->type == AST_PIPE_SEQ)
+	{
+		free_and_or_tokens_recursive(ast->u_ast.s_pipe_seq.left);
+		free_and_or_tokens_recursive(ast->u_ast.s_pipe_seq.right);
+	}
+	else if (ast->type == AST_SUBSHELL)
+	{
+		free_and_or_tokens_recursive(ast->u_ast.s_subshell.and_or);
+	}
+}
+
+int	teardown_free_and_or_subshell(void **state)
+{
+	t_ast	*ast;
+
+	if (!state || !*state)
+		return (0);
+	ast = (t_ast *)(*state);
+	free_and_or_tokens_recursive(ast);
+	free_ast(ast);
+	*state = NULL;
+	return (0);
+}

--- a/tests/eval/test_cd_eval.c
+++ b/tests/eval/test_cd_eval.c
@@ -55,20 +55,23 @@ void	test_eval_built_in_cd_path(void **state)
 	assert_non_null(ast);
 	env = create_shell_env(environ);
 	assert_non_null(env);
-	res = eval_ast(ast, env);
-	assert_non_null(res);
+	/* prepare directory before running the command */
 	mkdir(expected_dir, 0755);
 	buffer = calloc(1, PATH_MAX + 1);
 	if (!buffer)
 		return ;
-	old_dir = getcwd(buffer, PATH_MAX);
-	chdir(expected_dir);
+	/* save current dir */
+	old_dir = strdup(getcwd(buffer, PATH_MAX));
+	res = eval_ast(ast, env);
+	assert_non_null(res);
+	/* verify that the process actually changed to the expected dir */
 	curr_dir = getcwd(buffer, PATH_MAX);
-	assert_string_equal(res->curr_dir, curr_dir);
+	assert_string_equal(curr_dir, expected_dir);
 	assert_int_equal(res->exit_code, 0);
+	/* restore and cleanup */
 	chdir(old_dir);
 	rmdir(expected_dir);
-	free(res->curr_dir);
+	free(old_dir);
 	free(res);
 	free(buffer);
     destroy_shell_env(env);

--- a/tests/eval/test_cmd_external_pipe_eval.c
+++ b/tests/eval/test_cmd_external_pipe_eval.c
@@ -202,6 +202,7 @@ void	test_eval_pipe_large_buffer(void **state)
 
 	ast = (t_ast *)(*state);
 	env = create_shell_env(environ);
+	assert_non_null(env);
 	char *captured = eval_and_capture(ast, env, &res);
 	assert_non_null(res);
 	assert_string_equal(captured, "100000\n");
@@ -237,6 +238,7 @@ void	test_eval_pipe_builtin_to_external(void **state)
 
 	ast = (t_ast *)(*state);
 	env = create_shell_env(environ);
+	assert_non_null(env);
 	char *captured = eval_and_capture(ast, env, &res);
 	assert_non_null(res);
 	assert_string_equal(captured, "6\n");
@@ -271,6 +273,7 @@ void	test_eval_pipe_exit_code_success(void **state)
 
 	ast = (t_ast *)(*state);
 	env = create_shell_env(environ);
+	assert_non_null(env);
 	char *captured = eval_and_capture(ast, env, &res);
 	assert_int_equal(res->exit_code, 0);
 	free(captured);
@@ -303,6 +306,7 @@ void	test_eval_pipe_exit_code_fail(void **state)
 
 	ast = (t_ast *)(*state);
 	env = create_shell_env(environ);
+	assert_non_null(env);
 	char *captured = eval_and_capture(ast, env, &res);
 	assert_int_not_equal(res->exit_code, 0);
 	free(captured);
@@ -338,6 +342,7 @@ void	test_eval_pipe_error_propagation(void **state)
 
 	ast = (t_ast *)(*state);
 	env = create_shell_env(environ);
+	assert_non_null(env);
 	char *captured = eval_and_capture(ast, env, &res);
 	assert_non_null(res);
 	assert_string_equal(captured, "0\n");

--- a/tests/eval/test_eval_pipe_redir.c
+++ b/tests/eval/test_eval_pipe_redir.c
@@ -96,11 +96,11 @@ void	attach_redir_to_cmd(t_ast *cmd, t_ast *redir)
  */
 static void	free_io_file(t_ast *io_file)
 {
-	if (!io_file)
-		return ;
-	if (io_file->u_ast.s_io_file.op)
-		free_token(io_file->u_ast.s_io_file.op);
-	free(io_file);
+    if (!io_file)
+        return ;
+    if (io_file->u_ast.s_io_file.op)
+        free_token(io_file->u_ast.s_io_file.op);
+    free(io_file);
 }
 
 /*
@@ -108,38 +108,42 @@ static void	free_io_file(t_ast *io_file)
  */
 void	free_pipe_redir_ast_recursive(t_ast *ast)
 {
-	t_ast	*node;
-	t_ast	*next;
+    t_ast	*node;
+    t_ast	*next;
 
-	if (!ast)
-		return ;
-	if (ast->type == AST_PIPE_SEQ)
-	{
-		free_pipe_redir_ast_recursive(ast->u_ast.s_pipe_seq.left);
-		free_pipe_redir_ast_recursive(ast->u_ast.s_pipe_seq.right);
-		free(ast);
-		return ;
-	}
-	if (ast->type == AST_SIMPLE_CMD)
-	{
-		node = ast->u_ast.s_simple_cmd.cmd_prefix;
-		while (node)
-		{
-			next = node->u_ast.s_cmd_prefix.cmd_prefix;
-			free_io_file(node->u_ast.s_cmd_prefix.io_file);
-			free(node);
-			node = next;
-		}
-		node = ast->u_ast.s_simple_cmd.cmd_suffix;
-		while (node)
-		{
-			next = node->u_ast.s_cmd_suffix.cmd_suffix;
-			free_io_file(node->u_ast.s_cmd_suffix.io_file);
-			free(node);
-			node = next;
-		}
-	}
-	free(ast);
+    if (!ast)
+        return ;
+    if (ast->type == AST_PIPE_SEQ)
+    {
+        free_pipe_redir_ast_recursive(ast->u_ast.s_pipe_seq.left);
+        free_pipe_redir_ast_recursive(ast->u_ast.s_pipe_seq.right);
+        free(ast);
+        return ;
+    }
+    if (ast->type == AST_SIMPLE_CMD)
+    {
+        node = ast->u_ast.s_simple_cmd.cmd_prefix;
+        while (node)
+        {
+            next = node->u_ast.s_cmd_prefix.cmd_prefix;
+            free_io_file(node->u_ast.s_cmd_prefix.io_file);
+            free(node);
+            node = next;
+        }
+        ast->u_ast.s_simple_cmd.cmd_prefix = NULL;
+        node = ast->u_ast.s_simple_cmd.cmd_suffix;
+        while (node)
+        {
+            next = node->u_ast.s_cmd_suffix.cmd_suffix;
+            free_io_file(node->u_ast.s_cmd_suffix.io_file);
+            free(node);
+            node = next;
+        }
+        ast->u_ast.s_simple_cmd.cmd_suffix = NULL;
+        free_ast(ast);
+    }
+    else
+        free_ast(ast);
 }
 
 /*
@@ -147,9 +151,13 @@ void	free_pipe_redir_ast_recursive(t_ast *ast)
  */
 int	teardown_free_pipe_redir_ast(void **state)
 {
-	if (!state || !*state)
-		return (0);
-	free_pipe_redir_ast_recursive((t_ast *)(*state));
-	*state = NULL;
-	return (0);
+    t_ast	*ast;
+
+    if (state && *state)
+    {
+        ast = (t_ast *)*state;
+        free_pipe_redir_ast_recursive(ast);
+        *state = NULL;
+    }
+    return (0);
 }

--- a/tests/eval/test_eval_redir.c
+++ b/tests/eval/test_eval_redir.c
@@ -117,50 +117,84 @@ t_ast	*create_io_file_node(t_token_type type, char *filename)
 }
 
 /*
- *   helper: free a single io_file node completely
- */
 static void	free_io_file_node(t_ast *io_file)
 {
-	if (!io_file)
-		return ;
-	if (io_file->u_ast.s_io_file.op)
-		free_token(io_file->u_ast.s_io_file.op);
-	free(io_file);
+    if (!io_file)
+        return ;
+    if (io_file->u_ast.s_io_file.op)
+        free_token(io_file->u_ast.s_io_file.op);
+    free(io_file);
+}
+*/
+
+/*
+ *   helper: recursively clean fake tokens in AST before destruction
+ */
+static void	clean_fake_tokens_recursive(t_ast *ast)
+{
+    t_ast	*prefix;
+    t_ast	*suffix;
+
+    if (!ast)
+        return ;
+    if (ast->type == AST_PIPE_SEQ)
+    {
+        clean_fake_tokens_recursive(ast->u_ast.s_pipe_seq.left);
+        clean_fake_tokens_recursive(ast->u_ast.s_pipe_seq.right);
+    }
+    else if (ast->type == AST_SIMPLE_CMD)
+    {
+        prefix = ast->u_ast.s_simple_cmd.cmd_prefix;
+        while (prefix)
+        {
+            // We only free the 'op' token inside the io_file, 
+            // the node itself will be freed by free_ast later
+            if (prefix->u_ast.s_cmd_prefix.io_file)
+            {
+                t_ast *io = prefix->u_ast.s_cmd_prefix.io_file;
+                if (io->u_ast.s_io_file.op)
+                {
+                    free_token(io->u_ast.s_io_file.op);
+                    io->u_ast.s_io_file.op = NULL; // Prevent double free
+                }
+            }
+            prefix = prefix->u_ast.s_cmd_prefix.cmd_prefix;
+        }
+        suffix = ast->u_ast.s_simple_cmd.cmd_suffix;
+        while (suffix)
+        {
+            if (suffix->u_ast.s_cmd_suffix.io_file)
+            {
+                t_ast *io = suffix->u_ast.s_cmd_suffix.io_file;
+                if (io->u_ast.s_io_file.op)
+                {
+                    free_token(io->u_ast.s_io_file.op);
+                    io->u_ast.s_io_file.op = NULL;
+                }
+            }
+            suffix = suffix->u_ast.s_cmd_suffix.cmd_suffix;
+        }
+    }
 }
 
 /*
  *   teardown: free redir AST
+ *   Updated to handle recursive pipe structures and ensure tokens are freed
+ *   before delegating the rest to the standard free_ast.
  */
 int	teardown_free_redir_ast(void **state)
 {
-	t_ast	*ast;
-	t_ast	*prefix;
-	t_ast	*suffix;
-	t_ast	*next;
+    t_ast	*ast;
 
-	if (!state || !*state)
-		return (0);
-	ast = (t_ast *)(*state);
-	if (ast->type == AST_SIMPLE_CMD)
-	{
-		prefix = ast->u_ast.s_simple_cmd.cmd_prefix;
-		while (prefix)
-		{
-			next = prefix->u_ast.s_cmd_prefix.cmd_prefix;
-			free_io_file_node(prefix->u_ast.s_cmd_prefix.io_file);
-			free(prefix);
-			prefix = next;
-		}
-		suffix = ast->u_ast.s_simple_cmd.cmd_suffix;
-		while (suffix)
-		{
-			next = suffix->u_ast.s_cmd_suffix.cmd_suffix;
-			free_io_file_node(suffix->u_ast.s_cmd_suffix.io_file);
-			free(suffix);
-			suffix = next;
-		}
-	}
-	free(ast);
-	*state = NULL;
-	return (0);
+    if (!state || !*state)
+        return (0);
+    ast = (t_ast *)(*state);
+    
+    // First pass: clean up the manually allocated tokens that free_ast won't touch
+    clean_fake_tokens_recursive(ast);
+    
+    // Second pass: standard AST destruction
+    free_ast(ast);
+    *state = NULL;
+    return (0);
 }

--- a/tests/eval/test_exit_eval.c
+++ b/tests/eval/test_exit_eval.c
@@ -23,78 +23,313 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <syscall.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <errno.h>
 #include <cmocka.h>
 
-/*
- *   setup: exit to single args
- */
-int	setup_built_in_exit_single_arg_ast(void **state)
+typedef struct s_exit_test_ctx
 {
-	char	*args[] = {"1"};
-	*state = create_cmd_ast("exit", args, 1);
-	if (!*state)
-		return (-1);
-	return (0);
+	t_ast		*ast;
+	t_shell_env	*env;
+}				t_exit_test_ctx;
+
+static t_exit_test_ctx	ctx = {0};
+
+static char	*eval_and_catch_exit(t_ast *ast, t_shell_env *env,
+		t_shell_response **res, int *caught_status)
+{
+	int					outpipe[2];
+	int					errpipe[2];
+	pid_t				pid;
+	char				*buf;
+	size_t				total;
+	const size_t		CHUNK = 4096;
+	char				tmp[CHUNK];
+	ssize_t				r;
+	char				*nb;
+	int					status;
+	int					code;
+	t_shell_response	*child_res;
+
+	if (caught_status)
+		*caught_status = -1;
+	if (res)
+		*res = NULL;
+	if (pipe(outpipe) == -1)
+		return (NULL);
+	if (pipe(errpipe) == -1)
+	{
+		close(outpipe[0]);
+		close(outpipe[1]);
+		return (NULL);
+	}
+	pid = fork();
+	if (pid == -1)
+	{
+		close(outpipe[0]);
+		close(outpipe[1]);
+		close(errpipe[0]);
+		close(errpipe[1]);
+		return (NULL);
+	}
+	if (pid == 0)
+	{
+		/* Child: redirect stdout and stderr to pipes */
+		close(outpipe[0]);
+		close(errpipe[0]);
+		if (dup2(outpipe[1], STDOUT_FILENO) == -1)
+			_Exit(127);
+		if (dup2(errpipe[1], STDERR_FILENO) == -1)
+			_Exit(127);
+		close(outpipe[1]);
+		close(errpipe[1]);
+		
+		/* Mark this as a non-interactive shell to avoid "exit" message */
+		if (env)
+			env->interactive_owner = 0;
+		
+		/* Run the evaluator - if exit builtin is called, child_exit() will be called */
+		child_res = eval_ast(ast, env);
+		
+		/* If we reach here, exit was NOT called (e.g., "exit" with too many args) */
+		code = 1;
+		if (child_res)
+		{
+			code = child_res->exit_code;
+			free(child_res);
+		}
+		
+		/* Normal exit - exit builtin was not triggered or returned an error */
+		_Exit(code);
+	}
+	
+	/* parent */
+	close(outpipe[1]);
+	close(errpipe[1]);
+	
+	/* Read stderr (discard it for now, but we need to drain the pipe) */
+	while ((r = read(errpipe[0], tmp, CHUNK)) > 0)
+		;
+	close(errpipe[0]);
+	
+	/* Read stdout */
+	buf = NULL;
+	total = 0;
+	for (;;)
+	{
+		r = read(outpipe[0], tmp, CHUNK);
+		if (r <= 0)
+			break ;
+		nb = realloc(buf, total + r + 1);
+		if (!nb)
+		{
+			free(buf);
+			buf = NULL;
+			break ;
+		}
+		buf = nb;
+		memcpy(buf + total, tmp, r);
+		total += r;
+		buf[total] = '\0';
+	}
+	close(outpipe[0]);
+	
+	status = 0;
+	if (waitpid(pid, &status, 0) == -1)
+	{
+		if (caught_status)
+			*caught_status = -1;
+		free(buf);
+		return (NULL);
+	}
+	
+	if (WIFEXITED(status))
+	{
+		code = WEXITSTATUS(status);
+		if (caught_status)
+			*caught_status = code;
+		if (code == 0 && total == 0)
+		{
+			free(buf);
+			return (NULL);
+		}
+		if (code != 0)
+		{
+			free(buf);
+			return (NULL);
+		}
+		return (buf);
+	}
+	else if (WIFSIGNALED(status))
+	{
+		if (caught_status)
+			*caught_status = 128 + WTERMSIG(status);
+		free(buf);
+		return (NULL);
+	}
+	
+	if (caught_status)
+		*caught_status = -1;
+	return (buf);
 }
 
 /*
- *   test: exit should give error to many arguments
+ * setup: exit (no args)
  */
-void	test_eval_built_in_exit_single_arg_path(void **state)
+int	setup_built_in_exit_no_args_ast(void **state)
+{
+	extern char		**environ;
+
+	ctx.ast = create_cmd_ast("exit", NULL, 0);
+	if (!ctx.ast)
+		return (-1);
+	ctx.env = create_shell_env(environ);
+	if (!ctx.env)
+	{
+		free_cmd_ast(ctx.ast);
+		return (-1);
+	}
+	ctx.env->interactive_owner = 0;
+	ctx.env->last_exit_code = 0;
+	*state = &ctx;
+	return (0);
+}
+
+/* Test: 'exit' with no args
+	-> child should exit with status 0 and produce no stdout */
+void	test_eval_built_in_exit_no_args_caught(void **state)
 {
 	t_ast				*ast;
 	t_shell_response	*res;
 	t_shell_env			*env;
-	char				*expected = "too many arguments\n";
-	extern char			**environ;
+	t_exit_test_ctx		*ctx;
+	int					caught_status;
+	char				*out;
 
-	ast = (t_ast *)(*state);
+	ctx = (t_exit_test_ctx *)(*state);
+	ast = ctx->ast;
+	res = NULL;
+	caught_status = -1;
 	assert_non_null(ast);
-	env = create_shell_env(environ);
-	assert_non_null(env);
-	char *captured = eval_and_capture_ex(ast, env, &res);
-	assert_non_null(res);
-	assert_string_equal(captured, expected);
-	assert_int_equal(res->exit_code, 1);
-	free(captured);
-	free(res->curr_dir);
-	free(res);
-	destroy_shell_env(env);
+	env = ctx->env;
+	out = eval_and_catch_exit(ast, env, &res, &caught_status);
+	/* evaluator should have triggered exit(0) and not returned normal output */
+	assert_null(out);
+	assert_int_equal(caught_status, 0);
+	if (out)
+		free(out);
 }
 
 /*
- *   setup: exit to many args
+ * setup: exit 42 (numeric arg)
  */
-int	setup_built_in_exit_to_many_args_ast(void **state)
+int	setup_built_in_exit_numeric_arg_ast(void **state)
 {
-	char	*args[] = {"1", "1"};
-	*state = create_cmd_ast("exit", args, 2);
-	if (!*state)
+	char			*args[] = {"42"};
+	extern char		**environ;
+
+	ctx.ast = create_cmd_ast("exit", args, 1);
+	if (!ctx.ast)
+	{
 		return (-1);
+	}
+	ctx.env = create_shell_env(environ);
+	if (!ctx.env)
+	{
+		free_cmd_ast(ctx.ast);
+		return (-1);
+	}
+	ctx.env->interactive_owner = 0;
+	ctx.env->last_exit_code = 0;
+	*state = &ctx;
 	return (0);
 }
 
-/*
- *   test: exit should give error to many arguments
- */
-void	test_eval_built_in_exit_to_many_args_path(void **state)
+/* Test: 'exit 42' -> child should exit with status 42 and produce no stdout */
+void	test_eval_built_in_exit_numeric_arg_caught(void **state)
 {
+	t_exit_test_ctx		*ctx;
 	t_ast				*ast;
 	t_shell_response	*res;
 	t_shell_env			*env;
-	char				*expected = "too many arguments\n";
-	extern char			**environ;
+	int					caught_status;
+	char				*out;
 
-	ast = (t_ast *)(*state);
+	ctx = (t_exit_test_ctx *)(*state);
+	ast = ctx->ast;
+	res = NULL;
+	caught_status = -1;
 	assert_non_null(ast);
-	env = create_shell_env(environ);
-	assert_non_null(env);
-	char *captured = eval_and_capture_ex(ast, env, &res);
-	assert_non_null(res);
-	assert_string_equal(captured, expected);
-	assert_int_equal(res->exit_code, 1);
-	free(captured);
-	free(res->curr_dir);
-	free(res);
-	destroy_shell_env(env);
+	env = ctx->env;
+	out = eval_and_catch_exit(ast, env, &res, &caught_status);
+	assert_null(out);
+	assert_int_equal(caught_status, 42);
+	if (out)
+		free(out);
+}
+
+/*
+ * setup: exit notanumber (invalid arg)
+ */
+int	setup_built_in_exit_invalid_arg_ast(void **state)
+{
+	char			*args[] = {"notanumber"};
+	extern char		**environ;
+
+	ctx.ast = create_cmd_ast("exit", args, 1);
+	if (!ctx.ast)
+		return (-1);
+	ctx.env = create_shell_env(environ);
+	if (!ctx.env)
+	{
+		free_cmd_ast(ctx.ast);
+		return (-1);
+	}
+	ctx.env->interactive_owner = 0;
+	ctx.env->last_exit_code = 0;
+	*state = &ctx;
+	return (0);
+}
+
+/* Test: 'exit notanumber'
+	-> child should exit with a non-zero status and produce no stdout */
+void	test_eval_built_in_exit_invalid_arg_caught(void **state)
+{
+	t_exit_test_ctx		*ctx;
+	t_ast				*ast;
+	t_shell_response	*res;
+	t_shell_env			*env;
+	int					caught_status;
+	char				*out;
+
+	ctx = (t_exit_test_ctx *)(*state);
+	ast = ctx->ast;
+	res = NULL;
+	caught_status = -1;
+	assert_non_null(ast);
+	env = ctx->env;
+	out = eval_and_catch_exit(ast, env, &res, &caught_status);
+	assert_null(out);
+	assert_int_equal(caught_status, 2);
+	if (out)
+		free(out);
+}
+
+/* teardown: free ctx (ast + env) */
+int	teardown_free_exit_ctx(void **state)
+{
+	t_exit_test_ctx	*ctx;
+
+	if (!state || !*state)
+		return (0);
+	ctx = (t_exit_test_ctx *)(*state);
+	if (ctx->env)
+		destroy_shell_env(ctx->env);
+	if (ctx->ast)
+		free_ast(ctx->ast);
+	memset(ctx, 0, sizeof(t_exit_test_ctx));
+	*state = NULL;
+	return (0);
 }

--- a/tests/eval/test_export_eval.c
+++ b/tests/eval/test_export_eval.c
@@ -89,7 +89,8 @@ void	test_eval_built_in_export_no_args(void **state)
 	i = 0;
 	while (environ[i])
 	{
-		assert_true(export_var_in_output(captured, environ[i]));
+		if (strncmp(environ[i], "_", 1) != 0)
+			assert_true(export_var_in_output(captured, environ[i]));
 		i++;
 	}
 	assert_int_equal(res->exit_code, 0);

--- a/tests/eval/test_export_eval.c
+++ b/tests/eval/test_export_eval.c
@@ -89,7 +89,7 @@ void	test_eval_built_in_export_no_args(void **state)
 	i = 0;
 	while (environ[i])
 	{
-		if (strncmp(environ[i], "_", 1) != 0)
+		if (strncmp(environ[i], "_=", 2) != 0)
 			assert_true(export_var_in_output(captured, environ[i]));
 		i++;
 	}

--- a/tests/eval/test_heredoc_eval.c
+++ b/tests/eval/test_heredoc_eval.c
@@ -42,6 +42,8 @@ static int	setup_stdin_from_string(const char *input)
 		close(pipe_fd[1]);
 		return (-1);
 	}
+	/* Set close-on-exec so forked children that exec close this FD */
+	fcntl(original_stdin, F_SETFD, FD_CLOEXEC);
 	written = write(pipe_fd[1], input, strlen(input));
 	close(pipe_fd[1]);
 	if (written == -1)
@@ -2004,5 +2006,5 @@ int	teardown_free_heredoc_ast(void **state)
 	*state = NULL;
 	// Cleanup any temporary files
 	unlink("/tmp/heredoc_output.txt");
-	return (0);
+    return (0);
 }

--- a/tests/inc/tests.h
+++ b/tests/inc/tests.h
@@ -55,12 +55,16 @@ void	test_eval_built_in_env_not_empty(void **state);
 void	test_eval_built_in_env_contains_path(void **state);
 
 // setup for exit eval
-int		setup_built_in_exit_single_arg_ast(void **state);
-int		setup_built_in_exit_to_many_args_ast(void **state);
+int		setup_built_in_exit_no_args_ast(void **state);
+int		setup_built_in_exit_numeric_arg_ast(void **state);
+int		setup_built_in_exit_invalid_arg_ast(void **state);
 
 // tests for exit eval
-void	test_eval_built_in_exit_single_arg_path(void **state);
-void	test_eval_built_in_exit_to_many_args_path(void **state);
+void	test_eval_built_in_exit_no_args_caught(void **state);
+void	test_eval_built_in_exit_numeric_arg_caught(void **state);
+void	test_eval_built_in_exit_invalid_arg_caught(void **state);
+
+int     teardown_free_exit_ctx(void **state);
 
 // setup for export eval
 int		setup_built_in_export_no_args_ast(void **state);
@@ -205,17 +209,17 @@ int		setup_redir_append_no_newline(void **state);
 int		setup_redir_prefix_output(void **state);
 int		setup_redir_prefix_input(void **state);
 int		setup_redir_prefix_complex(void **state);
-int     setup_redir_prefix_output_append(void **state);
-int     setup_redir_prefix_append(void **state);
-int     setup_redir_prefix_multiple_output(void **state);
-int     setup_redir_prefix_multiple_input(void **state);
-int     setup_redir_prefix_builtin(void **state);
-int     setup_redir_prefix_builtin_pwd(void **state);
-int     setup_redir_prefix_external(void **state);
-int     setup_redir_prefix_suffix_mixed(void **state);
-int     setup_redir_prefix_invalid_path(void **state);
-int     setup_redir_prefix_input_nonexistent(void **state);
-int     setup_redir_prefix_multiple_append(void **state);
+int		setup_redir_prefix_output_append(void **state);
+int		setup_redir_prefix_append(void **state);
+int		setup_redir_prefix_multiple_output(void **state);
+int		setup_redir_prefix_multiple_input(void **state);
+int		setup_redir_prefix_builtin(void **state);
+int		setup_redir_prefix_builtin_pwd(void **state);
+int		setup_redir_prefix_external(void **state);
+int		setup_redir_prefix_suffix_mixed(void **state);
+int		setup_redir_prefix_invalid_path(void **state);
+int		setup_redir_prefix_input_nonexistent(void **state);
+int		setup_redir_prefix_multiple_append(void **state);
 
 // tests for redir eval
 void	test_eval_redir_output_create(void **state);
@@ -236,45 +240,45 @@ void	test_eval_redir_append_no_newline(void **state);
 void	test_eval_redir_prefix_output(void **state);
 void	test_eval_redir_prefix_input(void **state);
 void	test_eval_redir_prefix_complex(void **state);
-void    test_eval_redir_prefix_output_append(void **state);
-void    test_eval_redir_prefix_append(void **state);
-void    test_eval_redir_prefix_multiple_output(void **state);
-void    test_eval_redir_prefix_multiple_input(void **state);
-void    test_eval_redir_prefix_builtin(void **state);
-void    test_eval_redir_prefix_builtin_pwd(void **state);
-void    test_eval_redir_prefix_external(void **state);
-void    test_eval_redir_prefix_suffix_mixed(void **state);
-void    test_eval_redir_prefix_invalid_path(void **state);
-void    test_eval_redir_prefix_input_nonexistent(void **state);
-void    test_eval_redir_prefix_multiple_append(void **state);
+void	test_eval_redir_prefix_output_append(void **state);
+void	test_eval_redir_prefix_append(void **state);
+void	test_eval_redir_prefix_multiple_output(void **state);
+void	test_eval_redir_prefix_multiple_input(void **state);
+void	test_eval_redir_prefix_builtin(void **state);
+void	test_eval_redir_prefix_builtin_pwd(void **state);
+void	test_eval_redir_prefix_external(void **state);
+void	test_eval_redir_prefix_suffix_mixed(void **state);
+void	test_eval_redir_prefix_invalid_path(void **state);
+void	test_eval_redir_prefix_input_nonexistent(void **state);
+void	test_eval_redir_prefix_multiple_append(void **state);
 
 // setup for redir pipe eval
 int		setup_pipe_redir_input_to_wc(void **state);
 int		setup_pipe_redir_output(void **state);
 int		setup_pipe_redir_in_out(void **state);
 int		setup_pipe_redir_append(void **state);
-int     setup_pipe_redir_prefix_input_to_wc(void **state);
-int     setup_pipe_redir_prefix_output(void **state);
-int     setup_pipe_redir_prefix_in_out(void **state);
-int     setup_pipe_redir_prefix_append(void **state);
-//int     setup_pipe_redir_prefix_complex(void **state);
-//int     setup_pipe_redir_prefix_override_pipe(void **state);
-int     setup_pipe_redir_prefix_suffix_mixed(void **state);
-int     setup_pipe_redir_prefix_input_nonexistent(void **state);
+int		setup_pipe_redir_prefix_input_to_wc(void **state);
+int		setup_pipe_redir_prefix_output(void **state);
+int		setup_pipe_redir_prefix_in_out(void **state);
+int		setup_pipe_redir_prefix_append(void **state);
+// int     setup_pipe_redir_prefix_complex(void **state);
+// int     setup_pipe_redir_prefix_override_pipe(void **state);
+int		setup_pipe_redir_prefix_suffix_mixed(void **state);
+int		setup_pipe_redir_prefix_input_nonexistent(void **state);
 
 // setup for redir pipe eval
 void	test_eval_pipe_redir_input_to_wc(void **state);
 void	test_eval_pipe_redir_output(void **state);
 void	test_eval_pipe_redir_in_out(void **state);
 void	test_eval_pipe_redir_append(void **state);
-void    test_eval_pipe_redir_prefix_input_to_wc(void **state);
-void    test_eval_pipe_redir_prefix_output(void **state);
-void    test_eval_pipe_redir_prefix_in_out(void **state);
-void    test_eval_pipe_redir_prefix_append(void **state);
-//void    test_eval_pipe_redir_prefix_complex(void **state);
-void    test_eval_pipe_redir_prefix_override_pipe(void **state);
-void    test_eval_pipe_redir_prefix_suffix_mixed(void **state);
-void    test_eval_pipe_redir_prefix_input_nonexistent(void **state);
+void	test_eval_pipe_redir_prefix_input_to_wc(void **state);
+void	test_eval_pipe_redir_prefix_output(void **state);
+void	test_eval_pipe_redir_prefix_in_out(void **state);
+void	test_eval_pipe_redir_prefix_append(void **state);
+// void    test_eval_pipe_redir_prefix_complex(void **state);
+void	test_eval_pipe_redir_prefix_override_pipe(void **state);
+void	test_eval_pipe_redir_prefix_suffix_mixed(void **state);
+void	test_eval_pipe_redir_prefix_input_nonexistent(void **state);
 
 // setup for heredoc eval
 int		setup_heredoc_exec_cat_basic(void **state);
@@ -291,26 +295,26 @@ int		setup_heredoc_pipe_head(void **state);
 int		setup_heredoc_multiple(void **state);
 int		setup_heredoc_with_input_redir(void **state);
 int		setup_heredoc_pipe_tr(void **state);
-int     setup_heredoc_special_chars_content(void **state);
-int     setup_heredoc_long_content(void **state);
-int     setup_heredoc_whitespace_lines(void **state);
-int     setup_heredoc_limiter_in_content(void **state);
-int     setup_heredoc_numeric_limiter(void **state);
-int     setup_heredoc_single_char_limiter(void **state);
-int     setup_heredoc_with_env_vars(void **state);
-int     setup_heredoc_empty_lines(void **state);
-int     setup_heredoc_tabs_content(void **state);
-int     setup_heredoc_unicode_content(void **state);
-int     setup_heredoc_triple_redirect(void **state);
-int     setup_heredoc_after_append(void **state);
-int     setup_heredoc_sed_substitute(void **state);
-int     setup_heredoc_awk_process(void **state);
-int     setup_heredoc_tee_redirect(void **state);
-int     setup_heredoc_nested_pipes(void **state);
-int     setup_heredoc_parallel_commands(void **state);
-int     setup_heredoc_error_in_pipe(void **state);
-int     setup_heredoc_partial_match_limiter(void **state);
-int     setup_heredoc_case_sensitive_limiter(void **state);
+int		setup_heredoc_special_chars_content(void **state);
+int		setup_heredoc_long_content(void **state);
+int		setup_heredoc_whitespace_lines(void **state);
+int		setup_heredoc_limiter_in_content(void **state);
+int		setup_heredoc_numeric_limiter(void **state);
+int		setup_heredoc_single_char_limiter(void **state);
+int		setup_heredoc_with_env_vars(void **state);
+int		setup_heredoc_empty_lines(void **state);
+int		setup_heredoc_tabs_content(void **state);
+int		setup_heredoc_unicode_content(void **state);
+int		setup_heredoc_triple_redirect(void **state);
+int		setup_heredoc_after_append(void **state);
+int		setup_heredoc_sed_substitute(void **state);
+int		setup_heredoc_awk_process(void **state);
+int		setup_heredoc_tee_redirect(void **state);
+int		setup_heredoc_nested_pipes(void **state);
+int		setup_heredoc_parallel_commands(void **state);
+int		setup_heredoc_error_in_pipe(void **state);
+int		setup_heredoc_partial_match_limiter(void **state);
+int		setup_heredoc_case_sensitive_limiter(void **state);
 
 // tests for heredoc eval
 void	test_eval_heredoc_basic_structure(void **state);
@@ -336,26 +340,48 @@ void	test_eval_heredoc_pipe_head(void **state);
 void	test_eval_heredoc_multiple(void **state);
 void	test_eval_heredoc_with_input_redir(void **state);
 void	test_eval_heredoc_pipe_tr(void **state);
-void    test_eval_heredoc_special_chars_content(void **state);
-void    test_eval_heredoc_long_content(void **state);
-void    test_eval_heredoc_whitespace_lines(void **state);
-void    test_eval_heredoc_limiter_in_content(void **state);
-void    test_eval_heredoc_numeric_limiter(void **state);
-void    test_eval_heredoc_single_char_limiter(void **state);
-void    test_eval_heredoc_with_env_vars(void **state);
-void    test_eval_heredoc_empty_lines(void **state);
-void    test_eval_heredoc_tabs_content(void **state);
-void    test_eval_heredoc_unicode_content(void **state);
-void    test_eval_heredoc_triple_redirect(void **state);
-void    test_eval_heredoc_after_append(void **state);
-void    test_eval_heredoc_sed_substitute(void **state);
-void    test_eval_heredoc_awk_process(void **state);
-void    test_eval_heredoc_tee_redirect(void **state);
-void    test_eval_heredoc_nested_pipes(void **state);
-void    test_eval_heredoc_parallel_commands(void **state);
-void    test_eval_heredoc_error_in_pipe(void **state);
-void    test_eval_heredoc_partial_match_limiter(void **state);
-void    test_eval_heredoc_case_sensitive_limiter(void **state);
+void	test_eval_heredoc_special_chars_content(void **state);
+void	test_eval_heredoc_long_content(void **state);
+void	test_eval_heredoc_whitespace_lines(void **state);
+void	test_eval_heredoc_limiter_in_content(void **state);
+void	test_eval_heredoc_numeric_limiter(void **state);
+void	test_eval_heredoc_single_char_limiter(void **state);
+void	test_eval_heredoc_with_env_vars(void **state);
+void	test_eval_heredoc_empty_lines(void **state);
+void	test_eval_heredoc_tabs_content(void **state);
+void	test_eval_heredoc_unicode_content(void **state);
+void	test_eval_heredoc_triple_redirect(void **state);
+void	test_eval_heredoc_after_append(void **state);
+void	test_eval_heredoc_sed_substitute(void **state);
+void	test_eval_heredoc_awk_process(void **state);
+void	test_eval_heredoc_tee_redirect(void **state);
+void	test_eval_heredoc_nested_pipes(void **state);
+void	test_eval_heredoc_parallel_commands(void **state);
+void	test_eval_heredoc_error_in_pipe(void **state);
+void	test_eval_heredoc_partial_match_limiter(void **state);
+void	test_eval_heredoc_case_sensitive_limiter(void **state);
 
 int		teardown_free_heredoc_ast(void **state);
+
+// setup for logic eval
+int		setup_and_true_and_echo(void **state);
+int		setup_and_false_and_echo(void **state);
+int		setup_or_false_or_echo(void **state);
+int		setup_or_true_or_echo(void **state);
+int		setup_subshell_export(void **state);
+int		setup_subshell_echo(void **state);
+int		setup_subshell_exit_5(void **state);
+int		setup_subshell_cd(void **state);
+
+// tests for logic eval
+void	test_eval_and_runs_right_on_success(void **state);
+void	test_eval_and_skips_right_on_failure(void **state);
+void	test_eval_or_runs_right_on_failure(void **state);
+void	test_eval_or_skips_right_on_success(void **state);
+void	test_subshell_does_not_modify_parent_env(void **state);
+void	test_subshell_echo_outputs_and_exit_zero(void **state);
+void	test_subshell_exit_code_propagated(void **state);
+void	test_subshell_cd_does_not_change_parent_cwd(void **state);
+
+int		teardown_free_and_or_subshell(void **state);
 #endif

--- a/tests/lexer/test_lexer.c
+++ b/tests/lexer/test_lexer.c
@@ -66,7 +66,7 @@ void test_single_word(void **state)
 	assert_token(token, WORD, "echo");
 
 	token = get_next_token(lexer);
-	assert_token(token, END, NULL);
+	assert_token(token, NEWLINE, NULL);
 
 	ft_lstclear(&(lexer->tokens), &free_token);
 	free(lexer);
@@ -89,7 +89,7 @@ void test_multiple_words(void **state)
 	assert_token(token, WORD, "world");
 
 	token = get_next_token(lexer);
-	assert_token(token, END, NULL);
+	assert_token(token, NEWLINE, NULL);
 
 	ft_lstclear(&(lexer->tokens), &free_token);
 	free(lexer);
@@ -103,7 +103,7 @@ void test_empty_input(void **state)
 	assert_non_null(lexer);
 
 	t_token *token = get_next_token(lexer);
-	assert_token(token, END, NULL);
+	assert_token(token, NEWLINE, NULL);
 
 	ft_lstclear(&(lexer->tokens), &free_token);
 	free(lexer);
@@ -117,7 +117,7 @@ void test_whitespace_only(void **state)
 	assert_non_null(lexer);
 
 	t_token *token = get_next_token(lexer);
-	assert_token(token, END, NULL);
+	assert_token(token, NEWLINE, NULL);
 
 	ft_lstclear(&(lexer->tokens), &free_token);
 	free(lexer);

--- a/tests/parser/test_parser.c
+++ b/tests/parser/test_parser.c
@@ -31,7 +31,7 @@ typedef struct s_parse_result
 	t_lexer		*lexer;
 }	t_parse_result;
 
-t_parse_result *parse_input(const char *input)
+static t_parse_result	*test_parse_input(const char *input)
 {
 	t_parse_result *result = malloc(sizeof(t_parse_result));
 
@@ -77,7 +77,7 @@ void test_parser_simple_command_single_word(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo");
+	t_parse_result *result = test_parse_input("echo");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -95,7 +95,7 @@ void test_parser_simple_command_with_args(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello world");
+	t_parse_result *result = test_parse_input("echo hello world");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -117,7 +117,7 @@ void test_parser_simple_command_with_path(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("/bin/ls -la");
+	t_parse_result *result = test_parse_input("/bin/ls -la");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -133,7 +133,7 @@ void test_parser_command_multiple_args(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("ls -l -a -h");
+	t_parse_result *result = test_parse_input("ls -l -a -h");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -153,7 +153,7 @@ void test_parser_simple_pipe(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello | grep hello");
+	t_parse_result *result = test_parse_input("echo hello | grep hello");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -175,7 +175,7 @@ void test_parser_multiple_pipes(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("cat file.txt | grep test | wc -l");
+	t_parse_result *result = test_parse_input("cat file.txt | grep test | wc -l");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -200,7 +200,7 @@ void test_parser_output_redirect(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello > output.txt");
+	t_parse_result *result = test_parse_input("echo hello > output.txt");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -229,7 +229,7 @@ void test_parser_input_redirect(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("cat < input.txt");
+	t_parse_result *result = test_parse_input("cat < input.txt");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -255,7 +255,7 @@ void test_parser_append_redirect(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo test >> output.txt");
+	t_parse_result *result = test_parse_input("echo test >> output.txt");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -284,7 +284,7 @@ void test_parser_heredoc(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("cat << EOF");
+	t_parse_result *result = test_parse_input("cat << EOF");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -307,7 +307,7 @@ void test_parser_multiple_redirects(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("cat < input.txt > output.txt");
+	t_parse_result *result = test_parse_input("cat < input.txt > output.txt");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -339,7 +339,7 @@ void test_parser_and_operator(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello && echo world");
+	t_parse_result *result = test_parse_input("echo hello && echo world");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -361,7 +361,7 @@ void test_parser_or_operator(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello || echo world");
+	t_parse_result *result = test_parse_input("echo hello || echo world");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -380,7 +380,7 @@ void test_parser_mixed_logical_operators(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo a && echo b || echo c");
+	t_parse_result *result = test_parse_input("echo a && echo b || echo c");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -397,7 +397,7 @@ void test_parser_precedence_and_vs_pipe(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo a | grep a && echo b");
+	t_parse_result *result = test_parse_input("echo a | grep a && echo b");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -421,7 +421,7 @@ void test_parser_simple_subshell(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("(echo hello)");
+	t_parse_result *result = test_parse_input("(echo hello)");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -438,7 +438,7 @@ void test_parser_subshell_with_pipe(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("(echo hello | grep h)");
+	t_parse_result *result = test_parse_input("(echo hello | grep h)");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -454,7 +454,7 @@ void test_parser_nested_subshells(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("((echo hello))");
+	t_parse_result *result = test_parse_input("((echo hello))");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -474,7 +474,7 @@ void test_parser_subshell_with_logical_ops(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("(echo a && echo b)");
+	t_parse_result *result = test_parse_input("(echo a && echo b)");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -494,7 +494,7 @@ void test_parser_pipe_with_redirects(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("cat < input.txt | grep test > output.txt");
+	t_parse_result *result = test_parse_input("cat < input.txt | grep test > output.txt");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -512,7 +512,7 @@ void test_parser_logical_with_pipes(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo a | grep a && echo b | grep b");
+	t_parse_result *result = test_parse_input("echo a | grep a && echo b | grep b");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -530,7 +530,7 @@ void test_parser_subshell_in_pipeline(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("(echo hello) | grep h");
+	t_parse_result *result = test_parse_input("(echo hello) | grep h");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -548,7 +548,7 @@ void test_parser_subshell_and_logical(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("(echo a) && (echo b)");
+	t_parse_result *result = test_parse_input("(echo a) && (echo b)");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -570,7 +570,7 @@ void test_parser_empty_input(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("");
+	t_parse_result *result = test_parse_input("");
 	assert_non_null(result);
 
 	free_parse_result(result);
@@ -580,7 +580,7 @@ void test_parser_only_pipe(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("|");
+	t_parse_result *result = test_parse_input("|");
 	assert_non_null(result);
 	assert_int_equal(result->parser->has_error, 1);
 
@@ -591,7 +591,7 @@ void test_parser_pipe_without_right_side(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello |");
+	t_parse_result *result = test_parse_input("echo hello |");
 	assert_non_null(result);
 	assert_int_equal(result->parser->has_error, 1);
 
@@ -602,7 +602,7 @@ void test_parser_redirect_without_filename(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello >");
+	t_parse_result *result = test_parse_input("echo hello >");
 	assert_non_null(result);
 	assert_int_equal(result->parser->has_error, 1);
 
@@ -613,7 +613,7 @@ void test_parser_unclosed_subshell(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("(echo hello");
+	t_parse_result *result = test_parse_input("(echo hello");
 	assert_non_null(result);
 	assert_int_equal(result->parser->has_error, 1);
 
@@ -624,7 +624,7 @@ void test_parser_unopened_subshell(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello)");
+	t_parse_result *result = test_parse_input("echo hello)");
 	assert_non_null(result);
 	assert_int_equal(result->parser->has_error, 1);
 
@@ -635,7 +635,7 @@ void test_parser_double_pipe(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo | | cat");
+	t_parse_result *result = test_parse_input("echo | | cat");
 	assert_non_null(result);
 	assert_int_equal(result->parser->has_error, 1);
 
@@ -646,7 +646,7 @@ void test_parser_double_redirect(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo > > file");
+	t_parse_result *result = test_parse_input("echo > > file");
 	assert_null(result->ast);
 	assert_int_equal(result->parser->has_error, 1);
 
@@ -661,7 +661,7 @@ void test_parser_command_with_quoted_args(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo 'hello world'");
+	t_parse_result *result = test_parse_input("echo 'hello world'");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -677,7 +677,7 @@ void test_parser_redirect_with_quoted_filename(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo hello > \"output file.txt\"");
+	t_parse_result *result = test_parse_input("echo hello > \"output file.txt\"");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);
@@ -691,7 +691,7 @@ void test_parser_mixed_quotes(void **state)
 {
 	(void)state;
 
-	t_parse_result *result = parse_input("echo \"hello 'world'\"");
+	t_parse_result *result = test_parse_input("echo \"hello 'world'\"");
 	assert_non_null(result);
 	assert_non_null(result->ast);
 	assert_int_equal(result->parser->has_error, 0);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -33,7 +33,6 @@ static int	run_signal_tests(void)
 			setup_signal_test, teardown_signal_test),
 		cmocka_unit_test_setup_teardown(test_setup_signal_ignores_sigquit,
 			setup_signal_test, teardown_signal_test),
-
 		// SIGINT handler tests
 		cmocka_unit_test_setup_teardown(test_sigint_sets_global_flag,
 			setup_signal_test, teardown_signal_test),
@@ -41,31 +40,25 @@ static int	run_signal_tests(void)
 			setup_signal_test, teardown_signal_test),
 		cmocka_unit_test_setup_teardown(test_sigint_does_not_terminate_process,
 			setup_signal_test, teardown_signal_test),
-
 		// SIGQUIT handler tests
 		cmocka_unit_test_setup_teardown(test_sigquit_is_ignored,
 			setup_signal_test, teardown_signal_test),
 		cmocka_unit_test_setup_teardown(test_sigquit_multiple_times_ignored,
 			setup_signal_test, teardown_signal_test),
-
 		// Child process tests
 		cmocka_unit_test_setup_teardown(test_sigint_in_child_process,
 			setup_signal_test, teardown_signal_test),
 		cmocka_unit_test_setup_teardown(test_child_inherits_signal_handlers,
 			setup_signal_test, teardown_signal_test),
-
 		// Signal restoration tests
 		cmocka_unit_test_setup_teardown(test_signal_can_be_restored_to_default,
 			setup_signal_test, teardown_signal_test),
-
 		// Flag reset tests
 		cmocka_unit_test_setup_teardown(test_global_flag_can_be_reset,
 			setup_signal_test, teardown_signal_test),
-
 		// Concurrent signal tests
 		cmocka_unit_test_setup_teardown(test_sigint_and_sigquit_together,
 			setup_signal_test, teardown_signal_test),
-
 		// Edge case tests
 		cmocka_unit_test_setup_teardown(test_setup_signal_called_twice,
 			setup_signal_test, teardown_signal_test),
@@ -73,13 +66,11 @@ static int	run_signal_tests(void)
 			setup_signal_test, teardown_signal_test),
 		cmocka_unit_test_setup_teardown(test_rapid_signal_delivery,
 			setup_signal_test, teardown_signal_test),
-
 		// Sigaction tests
 		cmocka_unit_test_setup_teardown(test_sigaction_flags_are_correct,
 			setup_signal_test, teardown_signal_test),
 		cmocka_unit_test_setup_teardown(test_signal_mask_is_empty,
 			setup_signal_test, teardown_signal_test),
-
 		// Integration tests
 		cmocka_unit_test_setup_teardown(test_signal_handler_survives_child_exit,
 			setup_signal_test, teardown_signal_test),
@@ -239,10 +230,12 @@ static int	run_env_builtin_tests(void)
 static int	run_exit_builtin_tests(void)
 {
 	const struct CMUnitTest tests[] = {
-		cmocka_unit_test_setup_teardown(test_eval_built_in_exit_single_arg_path,
-			setup_built_in_exit_single_arg_ast, teardown_free_cmd_ast),
-		cmocka_unit_test_setup_teardown(test_eval_built_in_exit_to_many_args_path,
-			setup_built_in_exit_to_many_args_ast, teardown_free_cmd_ast),
+		cmocka_unit_test_setup_teardown(test_eval_built_in_exit_no_args_caught,
+			setup_built_in_exit_no_args_ast, teardown_free_exit_ctx),
+		cmocka_unit_test_setup_teardown(test_eval_built_in_exit_numeric_arg_caught,
+			setup_built_in_exit_numeric_arg_ast, teardown_free_exit_ctx),
+		cmocka_unit_test_setup_teardown(test_eval_built_in_exit_invalid_arg_caught,
+			setup_built_in_exit_invalid_arg_ast, teardown_free_exit_ctx),
 	};
 	printf("\n--- exit Builtin Tests ---\n");
 	return (cmocka_run_group_tests(tests, NULL, NULL));
@@ -465,22 +458,23 @@ static int	run_pipe_redir_tests(void)
 			setup_pipe_redir_in_out, teardown_free_pipe_redir_ast),
 		cmocka_unit_test_setup_teardown(test_eval_pipe_redir_append,
 			setup_pipe_redir_append, teardown_free_pipe_redir_ast),
-        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_input_to_wc,
-            setup_pipe_redir_prefix_input_to_wc, teardown_free_pipe_redir_ast),
-        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_output,
-            setup_pipe_redir_prefix_output, teardown_free_pipe_redir_ast),
-        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_in_out,
-            setup_pipe_redir_prefix_in_out, teardown_free_pipe_redir_ast),
-        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_append,
-            setup_pipe_redir_prefix_append, teardown_free_pipe_redir_ast),
-//        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_complex,
-//            setup_pipe_redir_prefix_complex, teardown_free_pipe_redir_ast),
-//        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_override_pipe,
-//            setup_pipe_redir_prefix_override_pipe, teardown_free_pipe_redir_ast),
-        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_suffix_mixed,
-            setup_pipe_redir_prefix_suffix_mixed, teardown_free_pipe_redir_ast),
-        cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_input_nonexistent,
-            setup_pipe_redir_prefix_input_nonexistent, teardown_free_pipe_redir_ast),
+		cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_input_to_wc,
+			setup_pipe_redir_prefix_input_to_wc, teardown_free_pipe_redir_ast),
+		cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_output,
+			setup_pipe_redir_prefix_output, teardown_free_pipe_redir_ast),
+		cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_in_out,
+			setup_pipe_redir_prefix_in_out, teardown_free_pipe_redir_ast),
+		cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_append,
+			setup_pipe_redir_prefix_append, teardown_free_pipe_redir_ast),
+//      cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_complex,
+//            setup_pipe_redir_prefix_complex,teardown_free_pipe_redir_ast),
+//      cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_override_pipe,
+//            setup_pipe_redir_prefix_override_pipe,teardown_free_pipe_redir_ast),
+		cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_suffix_mixed,
+			setup_pipe_redir_prefix_suffix_mixed, teardown_free_pipe_redir_ast),
+		cmocka_unit_test_setup_teardown(test_eval_pipe_redir_prefix_input_nonexistent,
+			setup_pipe_redir_prefix_input_nonexistent,
+			teardown_free_pipe_redir_ast),
 	};
 	printf("\n--- pipe with redirection Tests ---\n");
 	return (cmocka_run_group_tests(tests, NULL, NULL));
@@ -562,6 +556,30 @@ static int	run_heredoc_tests(void)
 	return (cmocka_run_group_tests(tests, NULL, NULL));
 }
 
+static int	run_and_or_subshell_tests(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test_setup_teardown(test_eval_and_runs_right_on_success,
+			setup_and_true_and_echo, teardown_free_and_or_subshell),
+		cmocka_unit_test_setup_teardown(test_eval_and_skips_right_on_failure,
+			setup_and_false_and_echo, teardown_free_and_or_subshell),
+		cmocka_unit_test_setup_teardown(test_eval_or_runs_right_on_failure,
+			setup_or_false_or_echo, teardown_free_and_or_subshell),
+		cmocka_unit_test_setup_teardown(test_eval_or_skips_right_on_success,
+			setup_or_true_or_echo, teardown_free_and_or_subshell),
+		cmocka_unit_test_setup_teardown(test_subshell_does_not_modify_parent_env,
+			setup_subshell_export, teardown_free_and_or_subshell),
+		cmocka_unit_test_setup_teardown(test_subshell_echo_outputs_and_exit_zero,
+			setup_subshell_echo, teardown_free_and_or_subshell),
+		cmocka_unit_test_setup_teardown(test_subshell_exit_code_propagated,
+			setup_subshell_exit_5, teardown_free_and_or_subshell),
+		cmocka_unit_test_setup_teardown(test_subshell_cd_does_not_change_parent_cwd,
+			setup_subshell_cd, teardown_free_and_or_subshell),
+	};
+	printf("\n--- and/or/subshell eval Tests ---\n");
+	return (cmocka_run_group_tests(tests, NULL, NULL));
+}
+
 static void	print_usage(void)
 {
 	printf("Usage: ./run_tests [OPTIONS]\n");
@@ -578,8 +596,9 @@ static void	print_usage(void)
 	printf("  external     Run external commands tests only\n");
 	printf("  pipe         Run pipe tests only\n");
 	printf("  redir        Run redirection tests only\n");
-	printf("  piredir       Run pipe with redirection tests only\n");
+	printf("  piredir      Run pipe with redirection tests only\n");
 	printf("  heredoc      Run heredoc tests only\n");
+	printf("  aos          Run logic (and/or/subshell) tests only\n");
 	printf("  -h, --help   Show this help message\n");
 }
 int	main(int argc, char *argv[])
@@ -669,6 +688,11 @@ int	main(int argc, char *argv[])
 			printf("\n=== Running Heredoc Tests ===\n");
 			return (run_heredoc_tests());
 		}
+		if (strcmp(argv[1], "aos") == 0)
+		{
+			printf("\n=== Running AND/OR/SUBSHELL Tests ===\n");
+			return (run_and_or_subshell_tests());
+		}
 		printf("Unknown option: %s\n", argv[1]);
 		print_usage();
 		return (1);
@@ -716,10 +740,13 @@ int	main(int argc, char *argv[])
 		failed += result;
 	result = run_pipe_redir_tests();
 	if (result != 0)
-		failed += result;	
+		failed += result;
 	result = run_heredoc_tests();
 	if (result != 0)
-		failed += result;	
+		failed += result;
+	result = run_and_or_subshell_tests();
+	if (result != 0)
+		failed += result;
 	printf("\n=== Test Suite Complete ===\n");
 	if (failed > 0)
 		printf("Total failures: %d\n", failed);

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -17,12 +17,267 @@
    ...
 }
 
-# tester token creation
+# Fork-related "still reachable" from test helpers
+# These are not real leaks - memory is inherited by forked children
+# and freed properly in the parent after children exit
+
 {
-   test_io_file_token_in_fork
+   test_create_cmd_ast_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:create_cmd_ast
+   ...
+}
+
+{
+   test_create_pipeline_ast_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:create_pipeline_ast
+   ...
+}
+
+{
+   test_create_io_file_node_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:create_io_file_node
+   ...
+}
+
+# And/Or test token allocations in forked children
+{
+   test_and_or_create_token_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable,definite,indirect
+   fun:malloc
+   ...
+   fun:create_token
+   fun:make_and_or_ast
+   ...
+}
+
+# Pipe+redir test helpers in forked children
+{
+   test_attach_redir_suffix_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:attach_redir_suffix
+   ...
+}
+
+{
+   test_attach_redir_prefix_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:attach_redir_prefix
+   ...
+}
+
+{
+   test_create_pipe_with_redir_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:create_pipe_with_redir
+   ...
+}
+
+# Subshell AST in forked children
+{
+   test_make_subshell_ast_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:make_subshell_ast
+   ...
+}
+
+# io_file node token in forked children (definitely lost in child)
+{
+   test_create_io_file_node_definite_in_fork
    Memcheck:Leak
    match-leak-kinds: definite
    fun:calloc
    fun:create_io_file_node
+   ...
+}
+
+# Shell environment allocations in forked children
+# These are not real leaks - child processes inherit parent memory
+# and exit without returning to cleanup code
+{
+   shell_env_in_fork_calloc
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:ft_calloc
+   fun:create_shell_env
+   ...
+}
+
+{
+   shell_env_hashtable_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:ft_calloc
+   fun:hashtable_create
+   fun:create_shell_env
+   ...
+}
+
+{
+   shell_env_hashtable_set_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   ...
+   fun:hashtable_set
+   fun:create_shell_env
+   ...
+}
+
+{
+   shell_env_strdup_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:ft_strdup
+   ...
+   fun:create_shell_env
+   ...
+}
+
+{
+   shell_env_lstnew_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:ft_lstnew
+   ...
+   fun:create_shell_env
+   ...
+}
+
+{
+   shell_env_expand_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:ft_calloc
+   fun:hashtable_expand
+   ...
+   fun:create_shell_env
+   ...
+}
+
+# capture_io.c allocations in forked children
+{
+   capture_end_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:capture_end
+   ...
+}
+
+# eval_ast response allocation in forked children
+{
+   eval_ast_response_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:ft_calloc
+   fun:eval_ast
+   ...
+}
+
+# cmd_response allocation in forked children
+{
+   create_cmd_res_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   fun:malloc
+   fun:ft_calloc
+   fun:create_cmd_res
+   ...
+}
+
+# General allocations in forked pipe/subshell children
+{
+   pipe_child_allocations
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   ...
+   fun:eval_pipe_recursive
+   ...
+}
+
+{
+   subshell_child_allocations
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   ...
+   fun:eval_subshell
+   ...
+}
+
+# Realloc in capture_end
+{
+   capture_end_realloc
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   fun:capture_end
+   ...
+}
+
+# Heredoc filename allocations in forked children
+# When process_heredocs runs, it allocates a temp filename
+# This is properly freed in parent via cleanup_heredoc_files
+# but child processes inherit and exit without cleanup
+{
+   heredoc_filename_strjoin_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ft_strjoin
+   fun:generate_heredoc_filename
+   ...
+}
+
+{
+   heredoc_filename_itoa_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ft_itoa
+   fun:generate_heredoc_filename
+   ...
+}
+
+# Heredoc processing in forked children
+{
+   process_heredocs_in_fork
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   ...
+   fun:process_heredocs
+   ...
+}
+
+# Test setup allocations that leak in forked children
+{
+   test_setup_calloc_in_fork
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:setup_heredoc_*
    ...
 }


### PR DESCRIPTION
## 📝 Description

Support for and/or/subshell and major fix in pipe/builtins/redir

## 🎯 Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [X] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [X] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [X] ✅ Test update
- [X] 🔧 Build/CI configuration change

## 🔗 Related Issue

Closes #26 

## 🧪 Testing

### Test Environment

- OS: [Ubuntu 22.04]
- Compiler: [clang 12.0.1]

# Test Cases: AND/OR and Subshell Evaluation

## AND (`&&`) Operator Tests

- [x] **Test case 1:** `test_eval_and_runs_right_on_success`  
  Verifies that `/bin/true && echo and_ok` executes the right side and outputs "and_ok" when left command succeeds (exit 0)

- [x] **Test case 2:** `test_eval_and_skips_right_on_failure`  
  Verifies that `/bin/false && echo and_should_not` skips the right side (empty output) when left command fails (exit 1)

## OR (`||`) Operator Tests

- [x] **Test case 3:** `test_eval_or_runs_right_on_failure`  
  Verifies that `/bin/false || echo or_ok` executes the right side and outputs "or_ok" when left command fails

- [x] **Test case 4:** `test_eval_or_skips_right_on_success`  
  Verifies that `/bin/true || echo or_should_not` skips the right side (empty output) when left command succeeds

## Subshell Tests

- [x] **Test case 5:** `test_subshell_does_not_modify_parent_env`  
  Verifies that `(export FOO=bar)` does not export `FOO` to the parent shell environment (isolation)

- [x] **Test case 6:** `test_subshell_echo_outputs_and_exit_zero`  
  Verifies that `(echo hello)` produces output "hello" and returns exit code 0

- [x] **Test case 7:** `test_subshell_exit_code_propagated`  
  Verifies that `(exit 5)` propagates exit code 5 to the parent process

- [x] **Test case 8:** `test_subshell_cd_does_not_change_parent_cwd`  
  Verifies that `(cd /tmp)` does not change the parent shell's current working directory

## Edge Cases Tested

- [x] Short-circuit evaluation for `&&` (right side not executed on failure)
- [x] Short-circuit evaluation for `||` (right side not executed on success)
- [x] Subshell environment isolation (exports don't leak)
- [x] Subshell working directory isolation (cd doesn't affect parent)
- [x] Exit code propagation from subshell to parent

## Compared Behavior with Bash

| Command | Bash Behavior | Minishell Behavior |
|---------|--------------|-------------------|
| `true && echo ok` | Prints "ok", exit 0 | ✓ Same |
| `false && echo x` | No output, exit 1 | ✓ Same |
| `false \|\| echo ok` | Prints "ok", exit 0 | ✓ Same |
| `true \|\| echo x` | No output, exit 0 | ✓ Same |
| `(export X=1); echo $X` | Empty (X not in parent) | ✓ Same |
| `(exit 5); echo $?` | Prints "5" | ✓ Same |
| `(cd /tmp); pwd` | Original directory | ✓ Same |

### Test Commands

```bash
# Paste the commands used to test your changes
make -C test run
